### PR TITLE
Moving over the adam.avdl file from adam-format.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+	<groupId>edu.berkeley.cs.amplab.adam</groupId>
+    <artifactId>bdg-formats</artifactId>
+	<version>0.6.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Big Data Genomics: Avro Formats</name>
+
+    <properties>
+        <avro.version>1.7.4</avro.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-maven-plugin</artifactId>
+                    <version>${avro.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>schemas</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                            <goal>protocol</goal>
+                            <goal>idl-protocol</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/resources/avro/adam.avdl
+++ b/src/main/resources/avro/adam.avdl
@@ -1,0 +1,314 @@
+@namespace("org.bdgenomics.adam.avro")
+protocol ADAM {
+
+record ADAMContig {
+  union { null, string } contigName = null;
+  union { null, long }   contigLength = null;
+  union { null, string } contigMD5 = null;
+  union { null, string } referenceURL = null;
+  union { null, string } assembly = null;
+  union { null, string } species = null;
+}
+
+record ADAMRecord {
+
+    /**
+     * These two fields, along with the two
+     * reference{Length, Url} fields at the bottom
+     * of the schema, collectively form the contents
+     * of the Sequence Dictionary embedded in the these
+     * records from the BAM / SAM itself.
+     */
+    union { null, ADAMContig } contig = null;
+
+    // 0-based reference position start
+    union { null, long } start = null;
+
+    union { null, int } mapq = null;
+    union { null, string } readName = null;
+    union { null, string } sequence = null;
+    union { null, string } mateReference = null;
+    union { null, long } mateAlignmentStart = null;
+    union { null, string } cigar = null;
+    union { null, string } qual = null;
+    union { null, string } recordGroupName = null;
+    union { null, int } recordGroupId = null;
+    union { int, null } basesTrimmedFromStart = 0;
+    union { int, null } basesTrimmedFromEnd = 0;
+
+    // Read flags (all default to false)
+    union { boolean, null } readPaired = false;
+    union { boolean, null } properPair = false;
+    union { boolean, null } readMapped = false;
+    union { boolean, null } mateMapped = false;
+    union { boolean, null } firstOfPair = false;
+    union { boolean, null } secondOfPair = false;
+    union { boolean, null } failedVendorQualityChecks = false;
+    union { boolean, null } duplicateRead = false;
+
+    // alignment flags (all default to null, as readMapped defaults to false)
+    union { boolean, null } readNegativeStrand = false; // aligned to reverse compliment
+    union { boolean, null } mateNegativeStrand = false; // mate aligned to reverse compliment
+    // primary vs. secondary vs. supplementary:
+    // - primary is either the best linear alignment or the "first" linear alignment 
+    //   in a chimeric alignment
+    // - supplementary is a non-primary linear alignment in a chimeric alignment
+    // - secondary is an alignment that is not the best alignment (an alignment that is
+    //   worse than the primary alignment) and that is not a supplimental linear alignment in a 
+    //   chimeric alignment (thus not supplimentary)
+    union { boolean, null } primaryAlignment = false;
+    union { boolean, null } secondaryAlignment = false;
+    union { boolean, null } supplementaryAlignment = false;
+
+    // Commonly used optional attributes
+    union { null, string } mismatchingPositions = null;
+    union { null, string } origQual = null;
+
+    // Remaining optional attributes flattened into a string
+    union { null, string } attributes = null;
+
+    // record group identifer from sequencing run
+    union { null, string } recordGroupSequencingCenter = null;
+    union { null, string } recordGroupDescription = null;
+    union { null, long } recordGroupRunDateEpoch = null;
+    union { null, string } recordGroupFlowOrder = null;
+    union { null, string } recordGroupKeySequence = null;
+    union { null, string } recordGroupLibrary = null;
+    union { null, int } recordGroupPredictedMedianInsertSize = null;
+    union { null, string } recordGroupPlatform = null;
+    union { null, string } recordGroupPlatformUnit = null;
+    union { null, string } recordGroupSample = null;
+
+    union { null, ADAMContig} mateContig = null;
+}
+
+enum Base {
+    A,
+    C,
+    T,
+    G,
+    U,
+    N, // any
+    X, // any
+    K, // keto: G/T
+    M, // aMino: A/C
+    R, // puRine: A/G
+    Y, // pYriminidine: C/T
+    S, // Strong: C/G
+    W, // Weak: A/T
+    B, // not A
+    V, // not T
+    H, // not G
+    D  // not C
+}
+
+record ADAMNucleotideContigFragment {
+    // stores a contig of nucleotides; this may be a reference chromosome, may be an
+    // assembly, may be a BAC. very long contigs (>1Mbp) need to be split into fragments.
+    // it seems that they are too long to load in a single go.
+    union { null, ADAMContig } contig = null;
+    union { null, string } description = null;
+    union { null, string } fragmentSequence = null; // sequence of bases in this fragment
+    union { null, int } fragmentNumber = null; // ordered number for this fragment
+    union { null, long } fragmentStartPosition = null; // position of first base of fragment in contig
+    union { null, int } numberOfFragmentsInContig = null; // total number of fragments in contig
+}
+
+record ADAMPileup {
+    union { null, ADAMContig } contig = null;
+    union { null, long } position = null;
+    union { null, int } rangeOffset = null;
+    union { null, int } rangeLength = null;
+    union { null, Base } referenceBase = null;
+    union { null, Base } readBase = null;
+    union { null, int } sangerQuality = null;
+    union { null, int } mapQuality = null;
+    union { null, int } numSoftClipped = null;
+    union { null, int } numReverseStrand = null;
+    union { null, int } countAtPosition = null;
+
+    union { null, string } readName = null;
+    union { null, long } readStart = null;
+    union { null, long } readEnd = null;
+
+    // record group identifer from sequencing run
+    union { null, string } recordGroupSequencingCenter = null;
+    union { null, string } recordGroupDescription = null;
+    union { null, long } recordGroupRunDateEpoch = null;
+    union { null, string } recordGroupFlowOrder = null;
+    union { null, string } recordGroupKeySequence = null;
+    union { null, string } recordGroupLibrary = null;
+    union { null, int } recordGroupPredictedMedianInsertSize = null;
+    union { null, string } recordGroupPlatform = null;
+    union { null, string } recordGroupPlatformUnit = null;
+    union { null, string } recordGroupSample = null;
+}
+
+record ADAMNestedPileup {
+     // nested pileup data type - contains reference to list of overlapping reads
+     // note: cannot be used with databases (e.g. hive/shark)
+     ADAMPileup pileup;
+     array<ADAMRecord> readEvidence;
+}
+
+
+record ADAMVariant {
+  union { null, ADAMContig } contig = null;
+  union { null, long } position = null;
+  union { null, long } exclusiveEnd = null;
+  union { null, string } referenceAllele = null;
+  union { null, string } variantAllele = null;
+}
+
+enum ADAMGenotypeAllele {
+  Ref,   // Genotype is the reference allele
+  Alt,   // Genotype is the alternate allele
+  OtherAlt, // Genotype is unspecified other alternate allele (e.g. split from multi-allelic)
+  NoCall // Genotype could not be called
+}
+
+enum ADAMGenotypeType {
+  HOM_REF,
+  HET,
+  HOM_ALT,
+  NO_CALL
+}
+
+// This record represents all stats that, inside a VCF, are stored outside of the
+// sample but are computed based on the samples.  For instance,  MAPQ0 is an aggregate
+// stat computed from all samples and stored inside the INFO line.
+record VariantCallingAnnotations {
+  // QUAL: Phred-scaled probability of error for this variant call.
+  union { null, float }   variantCallErrorProbability = null;
+
+  // FILTER: True or false implies that filters were applied and this variant PASSed or not.
+  // While 'null' implies not filters were applied.
+  union { null, boolean } variantIsPassing = null;
+  array <string> variantFilters = [];
+
+  union { null, int }     readDepth = null;
+  union { null, boolean } downsampled = null;
+  union { null, float }   baseQRankSum = null;
+  union { null, float }   clippingRankSum = null;
+  union { null, float }   fisherStrandBiasPValue = null; // Phred-scaled.
+  union { null, float }   haplotypeScore = null;
+  union { null, float }   inbreedingCoefficient = null;
+  union { null, float }   rmsMapQ = null;
+  union { null, int }     mapq0Reads = null;
+  union { null, float }   mqRankSum = null;
+  union { null, float }   variantQualityByDepth = null;
+  union { null, float }   readPositionRankSum = null;
+
+  // VQSR: Log-odds ratio of being a true vs false variant under trained
+  // Gaussian mixture model.
+  union { null, float }   vqslod = null;
+  union { null, string }  culprit = null;
+  union { null, boolean } usedForNegativeTrainingSet = null;
+  union { null, boolean } usedForPositiveTrainingSet = null;
+}
+
+record ADAMFlatGenotype {
+    union { null, string } referenceName = null;
+    union { null, long }   position = null;
+    union { null, string } referenceAllele = null;
+    union { null, array<string> } alleles = null;
+
+    union { null, array<int> } genotypeLikelihoods = null;
+    union { null, array<int> } alleleDepths = null;
+    union { null, int } readDepth = null;
+    union { null, int } genotypeQuality = null;
+
+    union { null, string } sampleId = null;
+}
+
+record ADAMGenotype {
+  ADAMVariant variant;
+  union { null, VariantCallingAnnotations } variantCallingAnnotations = null;
+
+  // Sample-level data, i.e. data specific to this particular sample
+  union { null, string }  sampleId = null;
+  union { null, string }  sampleDescription = null;
+  union { null, string }  processingDescription = null;
+
+  // Length is equal to the ploidy
+  union { null, array <ADAMGenotypeAllele> } alleles = null;
+
+  // Allele dosage (EC)
+  union { null, float } expectedAlleleDosage = null;
+
+  // How many reference and alternate reads (AD)
+  union { null, int }     referenceReadDepth = null;
+  union { null, int }     alternateReadDepth = null;
+  // How many reads and minimum reads at this position in this sample (DP, MIN_DP)
+  union { null, int }     readDepth = null;
+  union { null, int }     minReadDepth = null;
+  // The phred-scaled probability that we're correct for this genotype call (GQ)
+  union { null, int }     genotypeQuality = null;
+
+  // Phred-scaled. Always length 3 since all variants are bi-allelic
+  union { null, array<int> } genotypeLikelihoods = null;
+  union { null, array<int> } nonReferenceLikelihoods = null;
+
+  // Component statistics which comprise the Fisher's Exact Test to detect strand bias
+  union { null, array<int> } strandBiasComponents = null;
+
+  // In ADAM we split multi-allelic VCF lines into multiple
+  // single-alternate records.  This bit is set if that happened for this
+  // record.
+  union { boolean, null } splitFromMultiAllelic = false;
+
+  // Whether this is a phased genotype, and if so the phase set and quality
+  union { null, boolean } isPhased = null;
+  union { null, int }     phaseSetId = null;
+  union { null, int }     phaseQuality = null;
+}
+
+record VariantEffect
+{
+  union { null, string} hgvs = null;
+  union { null, string } referenceAminoAcid = null;
+  union { null, string } alternateAminoAcid = null;
+  union {null, string} geneId = null;
+  union {null, string} transcriptId = null;
+}
+
+record ADAMDatabaseVariantAnnotation {
+  union { null, ADAMVariant } variant;
+
+  union { null, int } dbSnpId = null;
+
+  //domain information
+  union {null, string} geneSymbol = null;
+
+  //clinical fields
+  union {null, string} omimId  = null;
+  union {null, string} cosmicId = null;
+  union {null, string} clinvarId  = null;
+  union {null, string} clinicalSignificance  = null;
+
+  //conservation
+  union { null, string } gerpNr  = null;
+  union { null, string } gerpRs  = null;
+  union { null, float } phylop  = null;
+  union { null, string } ancestralAllele  = null;
+
+  //population statistics
+  union {null, int} thousandGenomesAlleleCount = null;
+  union {null, float} thousandGenomesAlleleFrequency = null;
+
+  //effect
+  //TODO(arahuja): Parse into array
+  //array<VariantEffect> effects = null;
+
+  //predicted effects
+  union { null, float } siftScore = null;
+  union { null, float } siftScoreConverted = null;
+  union { null, string } siftPred = null;
+
+  union { null, float } mutationTasterScore = null;
+  union { null, float } mutationTasterScoreConverted = null;
+  union { null, string } mutationTasterPred = null;
+
+}
+
+}


### PR DESCRIPTION
In order to get the bdg-formats repository going, I've moved over the adam.avdl file
wholesale from the adam-format module in the main adam repo.

To avoid conflicts, I've given this repo its own pom.xml with an artifactId of 'bdg-formats',
but carrying over the same version, parent pom, etc.

Let me know if you think this should be done in a different way.  Since nothing is depending on bdg-formats at the moment, we have some freedom to evolve and update this repo independently.
