### PR TITLE
Removes unused record group ID field.

### DIFF
--- a/src/main/resources/avro/adam.avdl
+++ b/src/main/resources/avro/adam.avdl
@@ -50,7 +50,6 @@ record ADAMRecord {
     union { null, string } cigar = null;
     union { null, string } qual = null;
     union { null, string } recordGroupName = null;
-    union { null, int } recordGroupId = null;
     union { int, null } basesTrimmedFromStart = 0;
     union { int, null } basesTrimmedFromEnd = 0;
 


### PR DESCRIPTION
The record group ID field is currently unused. Additionally, after https://github.com/bigdatagenomics/adam/pull/285, record group IDs should be created on the fly if necessary by referencing a dictionary.
