### PR TITLE
Adding back the read end field.

### DIFF
--- a/src/main/resources/avro/adam.avdl
+++ b/src/main/resources/avro/adam.avdl
@@ -39,8 +39,9 @@ record ADAMRecord {
      */
     union { null, ADAMContig } contig = null;
 
-    // 0-based reference position start
+    // 0-based reference position start and end
     union { null, long } start = null;
+    union { null, long } end = null;
 
     union { null, int } mapq = null;
     union { null, string } readName = null;


### PR DESCRIPTION
The read end field is a lot less expensive to store than it is to compute on the fly, and having the read end around is useful for predicate pushdown (e.g., does a read overlap a region?)
