### PR TITLE
position, exclusiveEnd --> start, end

### DIFF
--- a/src/main/resources/avro/adam.avdl
+++ b/src/main/resources/avro/adam.avdl
@@ -164,8 +164,9 @@ record ADAMPileup {
 
 record ADAMVariant {
   union { null, ADAMContig } contig = null;
-  union { null, long } position = null;
-  union { null, long } exclusiveEnd = null;
+  // zero-based coordinate system, closed-open intervals
+  union { null, long } start = null;
+  union { null, long } end = null;
   union { null, string } referenceAllele = null;
   union { null, string } variantAllele = null;
 }


### PR DESCRIPTION
In an attempt to coalesce the variant/models across several different systems, I would like to recommend using start, end instead of position, exclusiveEnd.

| Source | Coordinate system | Interval type | Position fields | Contig names |
| --- | --- | --- | --- | --- |
| ADAM | 0-based | closed-open interval | position, exclusiveEnd | ? |
| Ensembl REST client | 1-based | closed interval | start, end | "1" |
| VCF file | 1-based | NA | position | "1" or "chr1" |
| GEMINI | 0-based | closed-open interval | start, end | "chr1" |
| Google Genomics | 1-based | NA | position | "1" or "chr1" |
| Global Alliance | 0-based | ? | position | "1" or "chr1" |

I'll will also attempt pull requests at Google Genomics and GA4GH for position --> start, end.
