### PR TITLE
Rename ADAMVariant variantAllele --> alternateAllele

### DIFF
--- a/src/main/resources/avro/adam.avdl
+++ b/src/main/resources/avro/adam.avdl
@@ -167,7 +167,7 @@ record ADAMVariant {
   union { null, long } position = null;
   union { null, long } exclusiveEnd = null;
   union { null, string } referenceAllele = null;
-  union { null, string } variantAllele = null;
+  union { null, string } alternateAllele = null;
 }
 
 enum ADAMGenotypeAllele {


### PR DESCRIPTION
Rename ADAMVariant variantAllele --> alternateAllele to match ADAMGenotypeAllele.Alt, ADAMGenotypeType.HOM_ALT, etc.
