### PR TITLE
Adding two new fields, 'featureType' and 'source', to ADAMRecord.

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -383,6 +383,11 @@ record Feature {
   // strand -- parsed into strand
   union { null, long } frame = null;
 
+  // Also, parsing out 'source' and 'feature' into separate fields, since we'll
+  // need to independently sort and handle these values.
+  union { null, string } source = null;
+  union { null, string } featureType = null;
+
   // narrowPeak format - (BED6+4)
   union { null, double } signalValue = null;
   union { null, double } pValue = null;


### PR DESCRIPTION
The existing implementation was parsing these into a single field, the
'trackName'.  That's fine, but we also need (for GTF/GFF files where
we'll be extracting and reconstructing gene models) a version of these
fields separated out in their original form.
