### PR TITLE
Changing read to alignment record.

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -57,7 +57,7 @@ record Contig {
   union { null, string } species = null;
 }
 
-record Read {
+record AlignmentRecord {
 
   /**
    The reference sequence details for the reference chromosome that


### PR DESCRIPTION
See #19.

AlignmentRecord is a preferable choice vs. Read, because a single read can have multiple alignments, thus a Read structure won't preserve the 1:1 mapping that it implies. For unaligned reads, an AlignmentRecord will just note that it is unaligned.
