### PR TITLE
[BDG-FORMATS-27] Add structural variant descriptor.

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -330,6 +330,49 @@ record Pileup {
   union { null, string } recordGroupSample = null;
 }
 
+/**
+ Descriptors for the type of a structural variant. The most specific descriptor
+ should be used, if possible. E.g., duplication should be used instead of
+ insertion if the inserted sequence is not novel. Tandem duplication should
+ be used instead of duplication if the duplication is known to follow the
+ duplicated sequence.
+ */
+enum StructuralVariantType {
+  DELETION,
+  INSERTION,
+  INVERSION,
+  MOBILE_INSERTION,
+  MOBILE_DELETION,
+  DUPLICATION,
+  TANDEM_DUPLICATION
+}
+
+record StructuralVariant {
+  /**
+   The type of this structural variant.
+   */
+  union { null, StructuralVariantType } type = null;
+  /**
+   The URL of the FASTA/NucleotideContig assembly for this structural variant,
+   if one is available.
+   */
+  union { null, string } assembly = null;
+
+  /**
+   Whether this structural variant call has precise breakpoints or not. Default
+   value is true. If the call is imprecise, confidence intervals should be provided.
+   */
+  union { boolean, null } precise = true;
+  /**
+   The size of the confidence window around the start of the structural variant.
+   */
+  union { null, int } startWindow = null;
+  /**
+   The size of the confidence window around the end of the structural variant.
+   */
+  union { null, int } endWindow = null;
+}
+
 record Variant {
   /**
    The reference contig that this variant exists on.
@@ -343,14 +386,22 @@ record Variant {
    The 0-based, exclusive end position of this variant on the reference contig.
    */
   union { null, long } end = null;
+
   /**
    A string describing the reference allele at this site.
    */
   union { null, string } referenceAllele = null;
   /**
-   A string describing the variant allele at this site.
+   A string describing the variant allele at this site. Should be left null if
+   the site is a structural variant.
    */
   union { null, string } alternateAllele = null;
+  /**
+   The structural variant at this site, if the alternate allele is a structural
+   variant. If the site is not a structural variant, this field should be left 
+   null.
+   */
+  union { null, StructuralVariant } svAllele = null;
 }
 
 /**


### PR DESCRIPTION
Adds a description for structural variants. I thought this would be useful as we are running into a need for it in downstream tools (e.g., https://github.com/hammerlab/guacamole/pull/130, https://github.com/bigdatagenomics/adam/issues/351).

CC @arahuja for comment.
