### PR TITLE
[BDG-FORMATS-31] Added sampleId to Pileup

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -328,6 +328,8 @@ record Pileup {
    */
   union { null, Base } readBase = null;
 
+  union { null, string } sampleId = null;
+
   /**
    The Phred scaled base quality at this position.
    */


### PR DESCRIPTION
This fixes the over-aggressive deletion of the sample fields from the
previous revision to the Pileup schema.
