### PR TITLE
Remove firstOfPair and secondOfPair fields from AlignmentRecord

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -180,8 +180,6 @@ record AlignmentRecord {
   union { boolean, null } properPair = false;
   union { boolean, null } readMapped = false;
   union { boolean, null } mateMapped = false;
-  union { boolean, null } firstOfPair = false;
-  union { boolean, null } secondOfPair = false;
   union { boolean, null } failedVendorQualityChecks = false;
   union { boolean, null } duplicateRead = false;
 


### PR DESCRIPTION
The `firstOfPair` and `secondOfPair` fields are made reduntant by the
addition of the `readNum` field:

    firstOfPair = readPaired && readNum == 1
    secondOfPair = readPaired && readNum == 2