### PR TITLE
Platform-specific data

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -262,6 +262,19 @@ record Sequence {
   union { null, string } qualities = null;
 }
 
+enum Platform {
+  IlluminaHT /* Illumina high-throughput */
+}
+
+record IlluminaHTInfo {
+  union { null, string } flowcellId;
+  union { null, int } lane;
+  union { null, int } tile;
+  union { null, int } surface;
+  union { null, int } xPosition;
+  union { null, int } yPosition;
+}
+
 /**
    The DNA fragment that is was targeted by the sequencer, resulting in
    one or more reads.
@@ -286,6 +299,13 @@ record Fragment {
    */
   array<Sequence> sequences = [];
   array<AlignmentRecord> alignments = [];
+
+
+  /**
+   Platform-specific information about this Fragment.
+   */
+  union { null, Platform } platformType;
+  union { null, IlluminaHTInfo } platformInfo;
 }
 
 /**


### PR DESCRIPTION
This pull requests adds support for representing platform-specific data to the schema.

The idea is to add a "type" field (`Fragment.platformType`, specifically) that tells us with what the platform of the `Fragment` was generated, and then store a platform-specific record in the `Fragment.platformInfo` field.

The change includes an enum to list the known platform types and a new record, `IlluminaHTInfo` for the Illumina platform.  The scheme can easily extended to other platforms by simply adding new enum values and defining additional platform-specific records.
