### PR TITLE
[BDG-FORMATS-54] Generalizing the Fragment type

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -58,7 +58,7 @@ record Contig {
 }
 
 record AlignmentRecord {
- 
+
   /**
    Read number within the array of fragment reads.
    */
@@ -284,8 +284,8 @@ record Sequence {
 }
 
 /**
-   A set of objects that should be physically analyzed/stored together.
-   Typically the result of some type of groupby operation.
+   A set of reads that should be analyzed/stored together physically.
+   Typically the result of a groupby operation.
 */
 record Bucket {
   /**
@@ -523,7 +523,7 @@ record VariantCallingAnnotations {
    * d = The number of negative strand reads covering the alternate allele
 
    This value takes the score:
-   
+
    -10 log((a + b)! * (c + d)! * (a + c)! * (b + d)! / (a! b! c! d! n!)
 
    Where n = a + b + c + d.
@@ -534,7 +534,7 @@ record VariantCallingAnnotations {
    The root mean square of the mapping qualities of reads covering this site.
    */
   union { null, float } rmsMapQ = null;
-  
+
   /**
    The number of reads at this site with mapping quality equal to 0.
    */

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -295,9 +295,8 @@ record Bucket {
   union { null, string } bucketName = null;
 
   /**
-   The grouped objects.  Only one of these arrays should be non-empty.
+   The array of grouped reads.  They may be unmapped.
    */
-  array<Sequence> sequences = [];
   array<AlignmentRecord> alignments = [];
 }
 

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -259,32 +259,43 @@ record AlignmentRecord {
   union { null, long } inferredInsertSize = null;
 }
 
+enum SequencingPlatform {
+  Illumina
+}
+
+record IlluminaInfo {
+  union { null, string } flowcellId;
+  union { null, int } lane;
+  union { null, int } tile;
+  union { null, int } surface;
+  union { null, int } xPosition;
+  union { null, int } yPosition;
+}
+
 record Sequence {
+  /**
+   Analogous to fastq
+   */
+  union { null, string } sequenceName = null;
   union { null, string } bases = null;
   union { null, string } qualities = null;
+  union { null, SequencingPlatform } platformType = null;
+  union { null, IlluminaInfo } platformInfo = null;
 }
 
 /**
-   The DNA fragment that is was targeted by the sequencer, resulting in
-   one or more reads.
+   A set of objects that should be physically analyzed/stored together.
+   Typically the result of some type of groupby operation.
 */
-record Fragment {
+record Bucket {
   /**
-   The name of this Fragment.
+   The name of this Bucket.  Can include the group key in the logical
+   group-by operation.
    */
-  union { null, string } readName = null;
-
-  union { null, string } instrument = null;
-  union { null, string } runId = null; 
+  union { null, string } bucketName = null;
 
   /**
-   Fragment's insert size derived from alignment, if the reads have been
-   aligned.
-   */
-  union { null, int } fragmentSize = null;
-
-  /**
-   The sequences read from this fragment.
+   The grouped objects.  Only one of these arrays should be non-empty.
    */
   array<Sequence> sequences = [];
   array<AlignmentRecord> alignments = [];


### PR DESCRIPTION
I think storing reads after a "groupby" operation has occurred is an excellent idea, as the reads will likely always be analyzed as a group.  Having multiple reads from a single fragment of DNA is one such use case, but there are others.  Droplet-seq is one that I am interested in.  Incorporating random
barcodes is another.

Here is a summary of my proposal, based in part on @ilveroluca's work:
- Support a fastq-like object `Sequence`, though I don't think this is strictly necessary.
- Rename to `Bucket`, as it sounds more general to my ears.
- Move run-specific or instrument-specific metadata into separate objects, as they don't necessarily make sense as top-level objects.
- Remove `fragmentSize`, as it's specific to one use case and it's rather easily computable.
- Support for multiple types of grouped objects.  What's the best way to deal with this?  `union` somehow?  I envision that we may add more types in the future that we'll want to persist as grouped objects.  At the moment, there is just a set of arrays for the type of objects that could be grouped.  This could be extended as we desire the ability to group other object types.
- Sequence and quality information from alignments should be retrieved from `AlignmentRecord`s.
- I don't think platform-specific information should be propagated through the entire chain of data types.  Why don't we include it in `Genotype`, then?  In my mind, any platform-specific analysis happens very early on, generally even before the fastq stage.  Therefore, I've moved platform-specific metadata into the `Sequence` object.

Fixes #54.
