### PR TITLE
Replaced Contig with ContigName in AlignmentRecord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.bdgenomics.bdg-formats</groupId>
   <artifactId>bdg-formats</artifactId>
-  <version>0.7.1-SNAPSHOT</version>
+  <version>0.7.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Big Data Genomics: Avro Formats</name>
 

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -98,7 +98,7 @@ record AlignmentRecord {
    this read is aligned to. If the read is unaligned, this field should
    be null.
    */
-  union { null, Contig } contig = null;
+  union { null, string } contigName = null;
 
   /**
    0 based reference position for the start of this read's alignment.
@@ -272,7 +272,7 @@ record AlignmentRecord {
    The reference contig of the mate of this read. Should be set to null if the
    mate is unaligned, or if the mate does not exist.
    */
-  union { null, Contig } mateContig = null;
+  union { null, string } mateContigName = null;
   /**
    The distance between this read and it's mate as inferred from alignment.
    */


### PR DESCRIPTION
Related to issue #983 in adam repo
Pulls 'Contig' out of 'AlignmentRecord' for efficiency issues, and replace it with 'ContigName' which is used as an index into the 'SequenceDictionary' which contains the `Contig` metadata details
