### PR TITLE
Flatten Variant into Genotype

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -604,6 +604,19 @@ record Genotype {
   union { null, Variant } variant = null;
 
   /**
+   The reference contig that this genotype's variant exists on.
+   */
+  union { null, string } contigName = null;
+  /**
+   The 0-based start position of this genotype's variant on the reference contig.
+   */
+  union { null, long } start = null;
+  /**
+   The 0-based, exclusive end position of this genotype's variant on the reference contig.
+   */
+  union { null, long } end = null;
+
+  /**
    Statistics collected at this site, if available.
    */
   union { null, VariantCallingAnnotations } variantCallingAnnotations = null;


### PR DESCRIPTION
Flattens entire Variant record into Genotype. Doing so will improve query speed when looking at regions by avoiding nested schemas in Parquet. 

Important things to note:
- This impacts any schemas that previously nested Variant. Right now this is just DatabaseVariantAnnotation, but will impact any other VariantAnnotation schemas, such as those sitting in  #67.
