### PR TITLE
Refactor variant and genotype annotations

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -22,8 +22,6 @@ protocol BDG {
 /**
  Record for describing a reference assembly. Not used for storing the contents
  of said assembly.
-
- @see NucleotideContigFragment
  */
 record Contig {
   /**
@@ -34,7 +32,7 @@ record Contig {
   /**
    The length of this contig.
    */
-  union { null, long }   contigLength = null;
+  union { null, long } contigLength = null;
 
   /**
    The MD5 checksum of the assembly for this contig.
@@ -130,20 +128,21 @@ record AlignmentRecord {
    are derived from a single fragment.
    */
   union { null, string } readName = null;
+
   /**
    The bases in this alignment. If the read has been hard clipped, this may
    not represent all the bases in the original read.
    */
   union { null, string } sequence = null;
+
   /**
    The per-base quality scores in this alignment. If the read has been hard
    clipped, this may not represent all the bases in the original read.
    Additionally, if the error scores have been recalibrated, this field
    will not contain the original base quality scores.
-
-   @see origQual
    */
   union { null, string } qual = null;
+
   /**
    The Compact Ideosyncratic Gapped Alignment Report (CIGAR) string that
    describes the local alignment of this read. Contains {length, operator}
@@ -178,29 +177,26 @@ record AlignmentRecord {
      aligned sequence is an alignment match to the reference, but a sequence
      mismatch (e.g., the bases are not equal to the reference). This can
      indicate a SNP or a read error.
-    */
+   */
   union { null, string } cigar = null;
+
   /**
    Stores the CIGAR string present before local indel realignment.
    Stores the same data as the OC field in the SAM format.
-
-   @see cigar
-    */
+   */
   union { null, string } oldCigar = null;
+
   /**
    The number of bases in this read/alignment that have been trimmed from the
    start of the read. By default, this is equal to 0. If the value is non-zero,
    that means that the start of the read has been hard-clipped.
-
-   @see cigar
    */
   union { int, null } basesTrimmedFromStart = 0;
+
   /**
    The number of bases in this read/alignment that have been trimmed from the
    end of the read. By default, this is equal to 0. If the value is non-zero,
    that means that the end of the read has been hard-clipped.
-
-   @see cigar
    */
   union { int, null } basesTrimmedFromEnd = 0;
 
@@ -217,33 +213,28 @@ record AlignmentRecord {
    defaults to false.
    */
   union { boolean, null } readNegativeStrand = false;
+
   /**
    True if the mate pair of this alignment is mapped as a reverse compliment.
    This field defaults to false.
    */
   union { boolean, null } mateNegativeStrand = false;
-  /**
-   This field is true if this alignment is either the best linear alignment,
-   or the first linear alignment in a chimeric alignment. Defaults to false.
 
-   @see secondaryAlignment
-   @see supplementaryAlignment
+  /**
+   True if this alignment is either the best linear alignment,
+   or the first linear alignment in a chimeric alignment. Defaults to false.
    */
   union { boolean, null } primaryAlignment = false;
-  /**
-   This field is true if this alignment is a lower quality linear alignment
-   for a multiply-mapped read. Defaults to false.
 
-   @see primaryAlignment
-   @see supplementaryAlignment
+  /**
+   True if this alignment is a lower quality linear alignment
+   for a multiply-mapped read. Defaults to false.
    */
   union { boolean, null } secondaryAlignment = false;
-  /**
-   This field is true if this alignment is a non-primary linear alignment in
-   a chimeric alignment. Defaults to false.
 
-   @see primaryAlignment
-   @see secondaryAlignment
+  /**
+   True if this alignment is a non-primary linear alignment in
+   a chimeric alignment. Defaults to false.
    */
   union { boolean, null } supplementaryAlignment = false;
 
@@ -263,16 +254,19 @@ record AlignmentRecord {
    mate is unaligned, or if the mate does not exist.
    */
   union { null, long } mateAlignmentStart = null;
+
   /**
    The end position of the mate of this read. Should be set to null if the
    mate is unaligned, or if the mate does not exist.
    */
   union { null, long } mateAlignmentEnd = null;
+
   /**
    The reference contig of the mate of this read. Should be set to null if the
    mate is unaligned, or if the mate does not exist.
    */
   union { null, string } mateContigName = null;
+
   /**
    The distance between this read and it's mate as inferred from alignment.
    */
@@ -305,30 +299,6 @@ record Fragment {
 }
 
 /**
- Enumeration for DNA/RNA bases. For codes outside of ACTGU, see the IUPAC
- resolution codes (http://www.bioinformatics.org/sms/iupac.html).
- */
-enum Base {
-  A,
-  C,
-  T,
-  G,
-  U,
-  N, // any
-  X, // any
-  K, // keto: G/T
-  M, // aMino: A/C
-  R, // puRine: A/G
-  Y, // pYriminidine: C/T
-  S, // Strong: C/G
-  W, // Weak: A/T
-  B, // not A
-  V, // not T
-  H, // not G
-  D  // not C
-}
-
-/**
  Stores a contig of nucleotides; this may be a reference chromosome, may be an
  assembly, may be a BAC. Very long contigs (>1Mbp) need to be split into fragments.
  It seems that they are too long to load in a single go. For best performance,
@@ -336,40 +306,48 @@ enum Base {
  fragments.
  */
 record NucleotideContigFragment {
+
   /**
    The contig identification descriptor for this contig.
    */
   union { null, Contig } contig = null;
+
   /**
    A description for this contig. When importing from FASTA, the FASTA header
    description line should be stored here.
    */
   union { null, string } description = null;
+
   /**
    The sequence of bases in this fragment.
    */
   union { null, string } fragmentSequence = null;
+
   /**
    In a fragmented contig, the position of this fragment in the set of fragments.
    Can be null if the contig is not fragmented.
    */
   union { null, int } fragmentNumber = null;
+
   /**
    The position of the first base of this fragment in the overall contig. E.g.,
    if all fragments are 10kbp and this is the third fragment in the contig,
    the start position would be 20000L.
    */
   union { null, long } fragmentStartPosition = null;
+
   /**
    The position of the last base of this fragment in the overall contig. E.g.,
    if all fragments are 10kbp and this is the third fragment in the contig,
    the end position would be 29999L.
    */
   union { null, long } fragmentEndPosition = null;
+
   /**
    The length of this fragment.
    */
   union { null, long } fragmentLength = null;
+
   /**
    The total count of fragments that this contig has been broken into. Can be
    null if the contig is not fragmented.
@@ -394,11 +372,16 @@ enum StructuralVariantType {
   TANDEM_DUPLICATION
 }
 
+/**
+ Structural variant.
+ */
 record StructuralVariant {
+
   /**
    The type of this structural variant.
    */
   union { null, StructuralVariantType } type = null;
+
   /**
    The URL of the FASTA/NucleotideContig assembly for this structural variant,
    if one is available.
@@ -410,17 +393,23 @@ record StructuralVariant {
    value is true. If the call is imprecise, confidence intervals should be provided.
    */
   union { boolean, null } precise = true;
+
   /**
    The size of the confidence window around the start of the structural variant.
    */
   union { null, int } startWindow = null;
+
   /**
    The size of the confidence window around the end of the structural variant.
    */
   union { null, int } endWindow = null;
 }
 
+/**
+ Variant.
+ */
 record Variant {
+
   /**
    The Phred scaled error probability of a variant, given the probabilities of
    the variant in a population.
@@ -431,10 +420,12 @@ record Variant {
    The reference contig that this variant exists on.
    */
   union { null, string } contigName = null;
+
   /**
    The 0-based start position of this variant on the reference contig.
    */
   union { null, long } start = null;
+
   /**
    The 0-based, exclusive end position of this variant on the reference contig.
    */
@@ -444,41 +435,44 @@ record Variant {
    A string describing the reference allele at this site.
    */
   union { null, string } referenceAllele = null;
+
   /**
    A string describing the variant allele at this site. Should be left null if
    the site is a structural variant.
    */
   union { null, string } alternateAllele = null;
+
   /**
    The structural variant at this site, if the alternate allele is a structural
    variant. If the site is not a structural variant, this field should be left
    null.
    */
-  union { null, StructuralVariant } svAllele = null;
+  union { null, StructuralVariant } structuralVariant = null;
 
   /**
    A boolean describing whether this variant call is somatic; in this case, the
-   `referenceAllele` will have been observed in another sample.
+   `referenceAllele` will have been observed in another sample.  VCF INFO header line
+   key SOMATIC.
    */
-  union { boolean, null } isSomatic = false;
+  union { boolean, null } somatic = false;
 }
 
 /**
  An enumeration that describes the allele that corresponds to a genotype. Can take
  the following values:
 
- * Ref: The genotype is the reference allele
- * Alt: The genotype is the alternate allele
- * OtherAlt: The genotype is an unspecified other alternate allele. This occurs
+ * REF: The genotype is the reference allele
+ * ALT: The genotype is the alternate allele
+ * OTHER_ALT: The genotype is an unspecified other alternate allele. This occurs
    in our schema when we have split a multi-allelic genotype into two genotype
    records.
- * NoCall: The genotype could not be called.
+ * NO_CALL: The genotype could not be called.
  */
 enum GenotypeAllele {
-  Ref,
-  Alt,
-  OtherAlt,
-  NoCall
+  REF,
+  ALT,
+  OTHER_ALT,
+  NO_CALL
 }
 
 /**
@@ -500,10 +494,12 @@ enum GenotypeType {
   NO_CALL
 }
 
-// This record represents all stats that, inside a VCF, are stored outside of the
-// sample but are computed based on the samples.  For instance,  MAPQ0 is an aggregate
-// stat computed from all samples and stored inside the INFO line.
-record VariantCallingAnnotations {
+/**
+ Genotype annotation; all stats that, inside a VCF, are stored outside of the
+ sample but are computed based on the samples.  For instance,  MAPQ0 is an aggregate
+ stat computed from all samples and stored inside the INFO line.
+ */
+record GenotypeAnnotation {
 
   // FILTER: True or false implies that filters were applied and this variant PASSed or not.
   // While 'null' implies not filters were applied.
@@ -520,7 +516,7 @@ record VariantCallingAnnotations {
    scores are separated by whether or not the base supports the reference or the
    alternate allele.
    */
-  union { null, float } baseQRankSum = null;
+  union { null, float } baseQualityRankSum = null;
 
   /**
    The Fisher's exact test score for the strand bias of the reference and alternate
@@ -542,19 +538,19 @@ record VariantCallingAnnotations {
   /**
    The root mean square of the mapping qualities of reads covering this site.
    */
-  union { null, float } rmsMapQ = null;
-  
+  union { null, float } rmsMappingQuality = null;
+
   /**
    The number of reads at this site with mapping quality equal to 0.
    */
-  union { null, int } mapq0Reads = null;
+  union { null, int } mappingQualityZeroReads = null;
 
   /**
    The Wilcoxon rank-sum test statistic of the mapping quality scores. The mapping
    quality scores are separated by whether or not the read supported the reference or the
    alternate allele.
    */
-  union { null, float } mqRankSum = null;
+  union { null, float } mappingQualityRankSum = null;
 
   /**
    The Wilcoxon rank-sum test statistic of the position of the base in the read at this site.
@@ -578,9 +574,9 @@ record VariantCallingAnnotations {
   array<float> genotypePosteriors = [];
 
   /**
-    The log-odds ratio of being a true vs. false variant under a trained statistical model.
-    This model can be a multivariate Gaussian mixture, support vector machine, etc.
-    */
+   The log-odds ratio of being a true vs. false variant under a trained statistical model.
+   This model can be a multivariate Gaussian mixture, support vector machine, etc.
+   */
   union { null, float } vqslod = null;
 
   /**
@@ -590,14 +586,16 @@ record VariantCallingAnnotations {
   union { null, string } culprit = null;
 
   /**
-   Additional feature info that doesn't fit into the standard fields above.
-
-   They are all encoded as (string, string) key-value pairs.
+   Additional genotype attributes that do not fit into the standard fields above.
    */
   map<string> attributes = {};
 }
 
+/**
+ Genotype.
+ */
 record Genotype {
+
   /**
    The variant called at this site.
    */
@@ -607,10 +605,12 @@ record Genotype {
    The reference contig that this genotype's variant exists on.
    */
   union { null, string } contigName = null;
+
   /**
    The 0-based start position of this genotype's variant on the reference contig.
    */
   union { null, long } start = null;
+
   /**
    The 0-based, exclusive end position of this genotype's variant on the reference contig.
    */
@@ -619,23 +619,13 @@ record Genotype {
   /**
    Statistics collected at this site, if available.
    */
-  union { null, VariantCallingAnnotations } variantCallingAnnotations = null;
+  union { null, GenotypeAnnotation } genotypeAnnotation = null;
 
   /**
    The unique identifier for this sample.
    */
-  union { null, string }  sampleId = null;
-  /**
-   A description of this sample.
-   */
-  union { null, string }  sampleDescription = null;
-  /**
-   A string describing the provenance of this sample and the processing applied
-   in genotyping this sample.
-   */
-  union { null, string }  processingDescription = null;
+  union { null, string } sampleId = null;
 
-  // Length is equal to the ploidy
   /**
    An array describing the genotype called at this site. The length of this
    array is equal to the ploidy of the sample at this site. This array may
@@ -650,50 +640,46 @@ record Genotype {
 
   /**
    The number of reads that show evidence for the reference at this site.
-
-   @see alternateReadDepth
-   @see readDepth
    */
-  union { null, int }     referenceReadDepth = null;
+  union { null, int } referenceReadDepth = null;
+
   /**
    The number of reads that show evidence for this alternate allele at this site.
-
-   @see referenceReadDepth
-   @see readDepth
    */
-  union { null, int }     alternateReadDepth = null;
+  union { null, int } alternateReadDepth = null;
+
   /**
    The total number of reads at this site. May not equal (alternateReadDepth +
    referenceReadDepth) if this site shows evidence of multiple alternate alleles.
 
-   @see referenceReadDepth
-   @see alternateReadDepth
-
-   @note Analogous to VCF's DP.
+   Analogous to VCF's DP.
    */
-  union { null, int }     readDepth = null;
+  union { null, int } readDepth = null;
+
   /**
    The minimum number of reads seen at this site across samples when joint
    calling variants.
 
-   @note Analogous to VCF's MIN_DP.
+   Analogous to VCF's MIN_DP.
    */
-  union { null, int }     minReadDepth = null;
+  union { null, int } minReadDepth = null;
+
   /**
    The phred-scaled probability that we're correct for this genotype call.
 
-   @note Analogous to VCF's GQ.
+   Analogous to VCF's GQ.
    */
-  union { null, int }     genotypeQuality = null;
+  union { null, int } genotypeQuality = null;
 
   /**
    Log scaled likelihoods that we have n copies of this alternate allele.
    The number of elements in this array should be equal to the ploidy at this
    site, plus 1.
 
-   @note Analogous to VCF's PL.
+   Analogous to VCF's PL.
    */
   array<float> genotypeLikelihoods = [];
+
   /**
    Log scaled likelihoods that we have n non-reference alleles at this site.
    The number of elements in this array should be equal to the ploidy at this
@@ -716,25 +702,20 @@ record Genotype {
 
   /**
    True if this genotype is phased.
-
-   @see phaseSetId
-   @see phaseQuality
    */
-  union { boolean, null } isPhased = false;
+  union { boolean, null } phased = false;
+
   /**
    The ID of this phase set, if this genotype is phased. Should only be populated
    if isPhased == true; else should be null.
-
-   @see isPhased
    */
-  union { null, int }     phaseSetId = null;
+  union { null, int } phaseSetId = null;
+
   /**
    Phred scaled quality score for the phasing of this genotype, if this genotype
    is phased. Should only be populated if isPhased == true; else should be null.
-
-   @see isPhased
    */
-  union { null, int }     phaseQuality = null;
+  union { null, int } phaseQuality = null;
 }
 
 /**
@@ -816,11 +797,6 @@ enum VariantAnnotationMessage {
  Annotation of a variant in the context of a feature, typically a transcript.
  */
 record TranscriptEffect {
-
-  /**
-   Alternate allele for this variant annotation.
-   */
-  union { null, string } alternateAllele = null;
 
   /**
    One or more annotations (also referred to as effects or consequences) of the
@@ -924,54 +900,116 @@ record TranscriptEffect {
 }
 
 /**
- Annotations of a variant, as produced by a tool such as SnpEff or Ensembl VEP.
+ Variant annotation.
  */
 record VariantAnnotation {
 
   /**
    Variant for this annotation.
    */
-  union { null, Variant } variant;
+  union { null, Variant } variant = null;
 
   /**
-   Zero or more transcript effects, per alternate allele and transcript (or other feature).
+   Ancestral allele, VCF INFO header line reserved key AA.
+   */
+  union { null, string } ancestralAllele = null;
+
+  /**
+   Allele count, VCF INFO header line reserved key AC.
+   */
+  union { null, string } alleleCount = null;
+
+  /**
+   Total read depth, VCF INFO header line reserved key AD.
+   */
+  union { null, int } readDepth = null;
+
+  /**
+   Forward strand read depth, VCF INFO header line reserved key ADF.
+   */
+  union { null, int } forwardReadDepth = null;
+
+  /**
+   Reverse strand read depth, VCF INFO header line reserved key ADR.
+   */
+  union { null, int } reverseReadDepth = null;
+
+  /**
+   Minor allele frequency, VCF INFO header line reserved key AF.
+   */
+  union { null, string } alleleFrequency = null;
+
+  /**
+   RMS base quality, VCF INFO header line reserved key BQ.
+   */
+  union { null, float } rmsBaseQuality = null;
+
+  /**
+   CIGAR string describing how to align an alternate allele to the reference
+   allele, VCF INFO header line reserved key CIGAR.
+   */
+  union { null, string } cigar = null;
+
+  /**
+   Membership in dbSNP, VCF info header line reserved key DB.
+   */
+  union { null, boolean } dbSnp = null;
+
+  /**
+   Combined depth across samples, VCF INFO header line reserved key DP.
+   */
+  union { null, int } combinedDepth = null;
+
+  /**
+   Membership in HapMap2, VCF INFO header line reserved key H2.
+   */
+  union { null, boolean } hapMap2 = null;
+
+  /**
+   Membership in HapMap3, VCF INFO header line reserved key H3.
+   */
+  union { null, boolean } hapMap3 = null;
+
+  /**
+   RMS mapping quality, VCF INFO header line reserved key MQ.
+   */
+  union { null, float } rmsMappingQuality = null;
+
+  /**
+   Number of MAPQ == 0 reads covering this record, VCF INFO header line reserved key MQ0.
+   */
+  union { null, int } mappingQualityZeroReads = null;
+
+  /**
+   Number of samples with data, VCF INFO header line reserved key NS.
+   */
+  union { null, int } samplesWithData = null;
+
+  /**
+   Strand bias, VCF INFO header line reserved key SB.
+   */
+  union { null, float } strandBias = null;
+
+  /**
+   Validated by follow up experiment, VCF INFO header line reserved key VALIDATED.
+   */
+  union { null, boolean } validated = null;
+
+  /**
+   Membership in 1000 Genomes, VCF INFO header line reserved key 1000G.
+   */
+  union { null, boolean } thousandGenomes = null;
+
+  /**
+   Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
+   one per transcript (or other feature).
    */
   array<TranscriptEffect> transcriptEffects = [];
-}
 
-record DatabaseVariantAnnotation {
-  union { null, Variant } variant;
-
-  union { null, int } dbSnpId = null;
-
-  //domain information
-  union {null, string} geneSymbol = null;
-
-  //clinical fields
-  union {null, string} omimId  = null;
-  union {null, string} cosmicId = null;
-  union {null, string} clinvarId  = null;
-  union {null, string} clinicalSignificance  = null;
-
-  //conservation
-  union { null, string } gerpNr  = null;
-  union { null, string } gerpRs  = null;
-  union { null, float } phylop  = null;
-  union { null, string } ancestralAllele  = null;
-
-  //population statistics
-  union {null, int} thousandGenomesAlleleCount = null;
-  union {null, float} thousandGenomesAlleleFrequency = null;
-
-  //predicted effects
-  union { null, float } siftScore = null;
-  union { null, float } siftScoreConverted = null;
-  union { null, string } siftPred = null;
-
-  union { null, float } mutationTasterScore = null;
-  union { null, float } mutationTasterScoreConverted = null;
-  union { null, string } mutationTasterPred = null;
-
+  /**
+   Additional variant attributes that do not fit into the standard fields above.
+   */
+  map<string> attributes = {};
 }
 
 /**
@@ -1172,7 +1210,7 @@ record Feature {
   /**
    True if this feature is circular.  Is_circular tag in GFF3.
    */
-  union { null, boolean } isCircular = null;
+  union { null, boolean } circular = null;
 
   /**
    Additional feature attributes.  Column 9 "attributes" in GFF3, excepting those


### PR DESCRIPTION
Fixes #89 

Also includes style fixes, removes used Base enum, and removes unused sample fields.