### PR TITLE
Code style and doc fixes

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -22,10 +22,9 @@ protocol BDG {
 /**
  Record for describing a reference assembly. Not used for storing the contents
  of said assembly.
-
- @see NucleotideContigFragment
  */
 record Contig {
+
   /**
    The name of this contig in the assembly (e.g., "chr1").
    */
@@ -34,7 +33,7 @@ record Contig {
   /**
    The length of this contig.
    */
-  union { null, long }   contigLength = null;
+  union { null, long } contigLength = null;
 
   /**
    The MD5 checksum of the assembly for this contig.
@@ -64,7 +63,11 @@ record Contig {
   union { null, int } referenceIndex = null;
 }
 
+/**
+ Record group metadata.
+ */
 record RecordGroupMetadata {
+
   /**
    Record group identifier.
    */
@@ -86,6 +89,9 @@ record RecordGroupMetadata {
   union { null, string } platformUnit = null;
 }
 
+/**
+ Alignment record.
+ */
 record AlignmentRecord {
  
   /**
@@ -108,8 +114,7 @@ record AlignmentRecord {
 
   /**
    0 based reference position where this read used to start before
-   local realignment.
-   Stores the same data as the OP field in the SAM format.
+   local realignment. Stores the same data as the OP field in the SAM format.
    */
   union { null, long } oldPosition = null;
 
@@ -130,20 +135,21 @@ record AlignmentRecord {
    are derived from a single fragment.
    */
   union { null, string } readName = null;
+
   /**
    The bases in this alignment. If the read has been hard clipped, this may
    not represent all the bases in the original read.
    */
   union { null, string } sequence = null;
+
   /**
    The per-base quality scores in this alignment. If the read has been hard
    clipped, this may not represent all the bases in the original read.
    Additionally, if the error scores have been recalibrated, this field
    will not contain the original base quality scores.
-
-   @see origQual
    */
   union { null, string } qual = null;
+
   /**
    The Compact Ideosyncratic Gapped Alignment Report (CIGAR) string that
    describes the local alignment of this read. Contains {length, operator}
@@ -178,29 +184,26 @@ record AlignmentRecord {
      aligned sequence is an alignment match to the reference, but a sequence
      mismatch (e.g., the bases are not equal to the reference). This can
      indicate a SNP or a read error.
-    */
+   */
   union { null, string } cigar = null;
+
   /**
    Stores the CIGAR string present before local indel realignment.
    Stores the same data as the OC field in the SAM format.
-
-   @see cigar
-    */
+   */
   union { null, string } oldCigar = null;
+
   /**
    The number of bases in this read/alignment that have been trimmed from the
    start of the read. By default, this is equal to 0. If the value is non-zero,
    that means that the start of the read has been hard-clipped.
-
-   @see cigar
    */
   union { int, null } basesTrimmedFromStart = 0;
+
   /**
    The number of bases in this read/alignment that have been trimmed from the
    end of the read. By default, this is equal to 0. If the value is non-zero,
    that means that the end of the read has been hard-clipped.
-
-   @see cigar
    */
   union { int, null } basesTrimmedFromEnd = 0;
 
@@ -217,33 +220,28 @@ record AlignmentRecord {
    defaults to false.
    */
   union { boolean, null } readNegativeStrand = false;
+
   /**
    True if the mate pair of this alignment is mapped as a reverse compliment.
    This field defaults to false.
    */
   union { boolean, null } mateNegativeStrand = false;
+
   /**
    This field is true if this alignment is either the best linear alignment,
    or the first linear alignment in a chimeric alignment. Defaults to false.
-
-   @see secondaryAlignment
-   @see supplementaryAlignment
    */
   union { boolean, null } primaryAlignment = false;
+
   /**
    This field is true if this alignment is a lower quality linear alignment
    for a multiply-mapped read. Defaults to false.
-
-   @see primaryAlignment
-   @see supplementaryAlignment
    */
   union { boolean, null } secondaryAlignment = false;
+
   /**
    This field is true if this alignment is a non-primary linear alignment in
    a chimeric alignment. Defaults to false.
-
-   @see primaryAlignment
-   @see secondaryAlignment
    */
   union { boolean, null } supplementaryAlignment = false;
 
@@ -263,16 +261,19 @@ record AlignmentRecord {
    mate is unaligned, or if the mate does not exist.
    */
   union { null, long } mateAlignmentStart = null;
+
   /**
    The end position of the mate of this read. Should be set to null if the
    mate is unaligned, or if the mate does not exist.
    */
   union { null, long } mateAlignmentEnd = null;
+
   /**
    The reference contig of the mate of this read. Should be set to null if the
    mate is unaligned, or if the mate does not exist.
    */
   union { null, string } mateContigName = null;
+
   /**
    The distance between this read and it's mate as inferred from alignment.
    */
@@ -280,17 +281,18 @@ record AlignmentRecord {
 }
 
 /**
-   The DNA fragment that is was targeted by the sequencer, resulting in
-   one or more reads.
-*/
+ The DNA fragment that is was targeted by the sequencer, resulting in
+ one or more reads.
+ */
 record Fragment {
+
   /**
-   The name of this Fragment.
+   The name of this fragment.
    */
   union { null, string } readName = null;
 
   union { null, string } instrument = null;
-  union { null, string } runId = null; 
+  union { null, string } runId = null;
 
   /**
    Fragment's insert size derived from alignment, if the reads have been
@@ -305,30 +307,6 @@ record Fragment {
 }
 
 /**
- Enumeration for DNA/RNA bases. For codes outside of ACTGU, see the IUPAC
- resolution codes (http://www.bioinformatics.org/sms/iupac.html).
- */
-enum Base {
-  A,
-  C,
-  T,
-  G,
-  U,
-  N, // any
-  X, // any
-  K, // keto: G/T
-  M, // aMino: A/C
-  R, // puRine: A/G
-  Y, // pYriminidine: C/T
-  S, // Strong: C/G
-  W, // Weak: A/T
-  B, // not A
-  V, // not T
-  H, // not G
-  D  // not C
-}
-
-/**
  Stores a contig of nucleotides; this may be a reference chromosome, may be an
  assembly, may be a BAC. Very long contigs (>1Mbp) need to be split into fragments.
  It seems that they are too long to load in a single go. For best performance,
@@ -336,45 +314,53 @@ enum Base {
  fragments.
  */
 record NucleotideContigFragment {
+
   /**
    The contig identification descriptor for this contig.
    */
   union { null, Contig } contig = null;
+
   /**
    A description for this contig. When importing from FASTA, the FASTA header
    description line should be stored here.
    */
   union { null, string } description = null;
+
   /**
    The sequence of bases in this fragment.
    */
   union { null, string } fragmentSequence = null;
+
   /**
    In a fragmented contig, the position of this fragment in the set of fragments.
    Can be null if the contig is not fragmented.
    */
   union { null, int } fragmentNumber = null;
+
   /**
    The position of the first base of this fragment in the overall contig. E.g.,
    if all fragments are 10kbp and this is the third fragment in the contig,
    the start position would be 20000L.
    */
   union { null, long } fragmentStartPosition = null;
+
   /**
    The position of the last base of this fragment in the overall contig. E.g.,
    if all fragments are 10kbp and this is the third fragment in the contig,
    the end position would be 29999L.
    */
   union { null, long } fragmentEndPosition = null;
+
   /**
    The length of this fragment.
    */
   union { null, long } fragmentLength = null;
+
   /**
    The total count of fragments that this contig has been broken into. Can be
    null if the contig is not fragmented.
    */
-  union { null, int } numberOfFragmentsInContig = null; // total number of fragments in contig
+  union { null, int } numberOfFragmentsInContig = null;
 }
 
 /**
@@ -385,20 +371,68 @@ record NucleotideContigFragment {
  duplicated sequence.
  */
 enum StructuralVariantType {
+
+  /**
+   Breakend.  VCF INFO reserved key "SVTYPE" value "BND".
+   */
+  BREAKEND,
+
+  /**
+   Copy number variable region (may be both deletion and duplication).
+   VCF INFO reserved key "SVTYPE" value "CNV".
+   */
+  COPY_NUMBER_VARIABLE,
+
+  /**
+   Deletion relative to the reference. VCF INFO reserved key "SVTYPE" value "DEL".
+   */
   DELETION,
-  INSERTION,
-  INVERSION,
-  MOBILE_INSERTION,
-  MOBILE_DELETION,
+
+  /**
+   Region of elevated copy number relative to the reference.
+   VCF INFO reserved key "SVTYPE" value "DUP".
+   */
   DUPLICATION,
+
+  /**
+   Insertion of novel sequence relative to the reference.
+   VCF INFO reserved key "SVTYPE" value "INS".
+   */
+  INSERTION,
+
+  /**
+   Inversion of reference sequence. VCF INFO reserved key "SVTYPE" value "INV".
+   */
+  INVERSION,
+
+  /**
+   Insertion of a mobile element relative to the reference.
+   VCF INFO reserved key "SVTYPE" value "INS:ME".
+   */
+  MOBILE_INSERTION,
+
+  /**
+   Deletion of mobile element relative to the reference.
+   VCF INFO reserved key "SVTYPE" value "DEL:ME".
+   */
+  MOBILE_DELETION,
+
+  /**
+   Tandem duplication. VCF INFO reserved key "SVTYPE" value "DUP:TANDEM".
+   */
   TANDEM_DUPLICATION
 }
 
+/**
+ Structural variant.
+ */
 record StructuralVariant {
+
   /**
    The type of this structural variant.
    */
   union { null, StructuralVariantType } type = null;
+
   /**
    The URL of the FASTA/NucleotideContig assembly for this structural variant,
    if one is available.
@@ -410,17 +444,23 @@ record StructuralVariant {
    value is true. If the call is imprecise, confidence intervals should be provided.
    */
   union { boolean, null } precise = true;
+
   /**
    The size of the confidence window around the start of the structural variant.
    */
   union { null, int } startWindow = null;
+
   /**
    The size of the confidence window around the end of the structural variant.
    */
   union { null, int } endWindow = null;
 }
 
+/**
+ Variant.
+ */
 record Variant {
+
   /**
    The Phred scaled error probability of a variant, given the probabilities of
    the variant in a population.
@@ -431,10 +471,12 @@ record Variant {
    The reference contig that this variant exists on.
    */
   union { null, string } contigName = null;
+
   /**
    The 0-based start position of this variant on the reference contig.
    */
   union { null, long } start = null;
+
   /**
    The 0-based, exclusive end position of this variant on the reference contig.
    */
@@ -444,11 +486,13 @@ record Variant {
    A string describing the reference allele at this site.
    */
   union { null, string } referenceAllele = null;
+
   /**
    A string describing the variant allele at this site. Should be left null if
    the site is a structural variant.
    */
   union { null, string } alternateAllele = null;
+
   /**
    The structural variant at this site, if the alternate allele is a structural
    variant. If the site is not a structural variant, this field should be left
@@ -458,51 +502,72 @@ record Variant {
 
   /**
    A boolean describing whether this variant call is somatic; in this case, the
-   `referenceAllele` will have been observed in another sample.
+   referenceAllele will have been observed in another sample.
    */
-  union { boolean, null } isSomatic = false;
+  union { boolean, null } somatic = false;
 }
 
 /**
- An enumeration that describes the allele that corresponds to a genotype. Can take
- the following values:
-
- * Ref: The genotype is the reference allele
- * Alt: The genotype is the alternate allele
- * OtherAlt: The genotype is an unspecified other alternate allele. This occurs
-   in our schema when we have split a multi-allelic genotype into two genotype
-   records.
- * NoCall: The genotype could not be called.
+ An enumeration that describes the allele that corresponds to a genotype.
  */
 enum GenotypeAllele {
-  Ref,
-  Alt,
-  OtherAlt,
-  NoCall
-}
 
-/**
- An enumeration that describes the characteristics of a genotype at a site. Can
- take the following values:
+  /**
+   The genotype is the reference allele.
+   */
+  REF,
 
- * HOM_REF: All genotypes at this site were called as the reference allele.
- * HET: Genotypes at this site were called as multiple different alleles. This
-   most commonly occurs if a diploid sample's genotype contains one reference
-   and one variant allele, but can also occur if the genotype contains multiple
-   alternate alleles.
- * HOM_ALT: All genotypes at this site were called as a single alternate allele.
- * NO_CALL: The genotype could not be called at this site.
- */
-enum GenotypeType {
-  HOM_REF,
-  HET,
-  HOM_ALT,
+  /**
+   The genotype is the alternate allele.
+   */
+  ALT,
+
+  /**
+   The genotype is an unspecified other alternate allele. This occurs in our schema
+   when we have split a multi-allelic genotype into two genotype records.
+   */
+  OTHER_ALT,
+
+  /**
+   The genotype could not be called.
+   */
   NO_CALL
 }
 
-// This record represents all stats that, inside a VCF, are stored outside of the
-// sample but are computed based on the samples.  For instance,  MAPQ0 is an aggregate
-// stat computed from all samples and stored inside the INFO line.
+/**
+ An enumeration that describes the characteristics of a genotype at a site.
+ */
+enum GenotypeType {
+
+  /**
+   All genotypes at this site were called as the reference allele.
+   */
+  HOM_REF,
+
+  /**
+   Genotypes at this site were called as multiple different alleles. This
+   most commonly occurs if a diploid sample's genotype contains one reference
+   and one variant allele, but can also occur if the genotype contains multiple
+   alternate alleles.
+   */
+  HET,
+
+  /**
+   All genotypes at this site were called as a single alternate allele.
+   */
+  HOM_ALT,
+
+  /**
+   The genotype could not be called at this site.
+   */
+  NO_CALL
+}
+
+/**
+ This record represents all stats that, inside a VCF, are stored outside of the
+ sample but are computed based on the samples. For instance, MAPQ0 is an aggregate
+ stat computed from all samples and stored inside the INFO line.
+ */
 record VariantCallingAnnotations {
 
   // FILTER: True or false implies that filters were applied and this variant PASSed or not.
@@ -578,9 +643,9 @@ record VariantCallingAnnotations {
   array<float> genotypePosteriors = [];
 
   /**
-    The log-odds ratio of being a true vs. false variant under a trained statistical model.
-    This model can be a multivariate Gaussian mixture, support vector machine, etc.
-    */
+   The log-odds ratio of being a true vs. false variant under a trained statistical model.
+   This model can be a multivariate Gaussian mixture, support vector machine, etc.
+   */
   union { null, float } vqslod = null;
 
   /**
@@ -591,13 +656,16 @@ record VariantCallingAnnotations {
 
   /**
    Additional feature info that doesn't fit into the standard fields above.
-
    They are all encoded as (string, string) key-value pairs.
    */
   map<string> attributes = {};
 }
 
+/**
+ Genotype.
+ */
 record Genotype {
+
   /**
    The variant called at this site.
    */
@@ -607,10 +675,12 @@ record Genotype {
    The reference contig that this genotype's variant exists on.
    */
   union { null, string } contigName = null;
+
   /**
    The 0-based start position of this genotype's variant on the reference contig.
    */
   union { null, long } start = null;
+
   /**
    The 0-based, exclusive end position of this genotype's variant on the reference contig.
    */
@@ -625,21 +695,22 @@ record Genotype {
    The unique identifier for this sample.
    */
   union { null, string }  sampleId = null;
+
   /**
    A description of this sample.
    */
   union { null, string }  sampleDescription = null;
+
   /**
    A string describing the provenance of this sample and the processing applied
    in genotyping this sample.
    */
   union { null, string }  processingDescription = null;
 
-  // Length is equal to the ploidy
   /**
    An array describing the genotype called at this site. The length of this
    array is equal to the ploidy of the sample at this site. This array may
-   reference OtherAlt alleles if this site is multi-allelic in this sample.
+   reference OTHER_ALT alleles if this site is multi-allelic in this sample.
    */
   array<GenotypeAllele> alleles = [];
 
@@ -650,50 +721,40 @@ record Genotype {
 
   /**
    The number of reads that show evidence for the reference at this site.
-
-   @see alternateReadDepth
-   @see readDepth
    */
-  union { null, int }     referenceReadDepth = null;
+  union { null, int } referenceReadDepth = null;
+
   /**
    The number of reads that show evidence for this alternate allele at this site.
-
-   @see referenceReadDepth
-   @see readDepth
    */
-  union { null, int }     alternateReadDepth = null;
+  union { null, int } alternateReadDepth = null;
+
   /**
    The total number of reads at this site. May not equal (alternateReadDepth +
    referenceReadDepth) if this site shows evidence of multiple alternate alleles.
-
-   @see referenceReadDepth
-   @see alternateReadDepth
-
-   @note Analogous to VCF's DP.
+   Analogous to VCF's DP.
    */
-  union { null, int }     readDepth = null;
+  union { null, int } readDepth = null;
+
   /**
    The minimum number of reads seen at this site across samples when joint
-   calling variants.
-
-   @note Analogous to VCF's MIN_DP.
+   calling variants. Analogous to VCF's MIN_DP.
    */
-  union { null, int }     minReadDepth = null;
+  union { null, int } minReadDepth = null;
+
   /**
    The phred-scaled probability that we're correct for this genotype call.
-
-   @note Analogous to VCF's GQ.
+   Analogous to VCF's GQ.
    */
-  union { null, int }     genotypeQuality = null;
+  union { null, int } genotypeQuality = null;
 
   /**
    Log scaled likelihoods that we have n copies of this alternate allele.
    The number of elements in this array should be equal to the ploidy at this
-   site, plus 1.
-
-   @note Analogous to VCF's PL.
+   site, plus 1. Analogous to VCF's PL.
    */
   array<float> genotypeLikelihoods = [];
+
   /**
    Log scaled likelihoods that we have n non-reference alleles at this site.
    The number of elements in this array should be equal to the ploidy at this
@@ -708,33 +769,27 @@ record Genotype {
   array<int> strandBiasComponents = [];
 
   /**
-   We split multi-allelic VCF lines into multiple
-   single-alternate records.  This bit is set if that happened for this
-   record.
+   We split multi-allelic VCF lines into multiple single-alternate records.
+   This bit is set if that happened for this record.
    */
   union { boolean, null } splitFromMultiAllelic = false;
 
   /**
    True if this genotype is phased.
-
-   @see phaseSetId
-   @see phaseQuality
    */
-  union { boolean, null } isPhased = false;
+  union { boolean, null } phased = false;
+
   /**
    The ID of this phase set, if this genotype is phased. Should only be populated
-   if isPhased == true; else should be null.
-
-   @see isPhased
+   if phased == true; else should be null.
    */
-  union { null, int }     phaseSetId = null;
+  union { null, int } phaseSetId = null;
+
   /**
    Phred scaled quality score for the phasing of this genotype, if this genotype
-   is phased. Should only be populated if isPhased == true; else should be null.
-
-   @see isPhased
+   is phased. Should only be populated if phased == true; else should be null.
    */
-  union { null, int }     phaseQuality = null;
+  union { null, int } phaseQuality = null;
 }
 
 /**
@@ -745,7 +800,7 @@ enum VariantAnnotationMessage {
   /**
    Chromosome does not exist in reference genome database. Typically indicates
    a mismatch between the chromosome names in the input file and the chromosome
-   names used in the reference genome.  Message code E1.
+   names used in the reference genome. Message code E1.
    */
   ERROR_CHROMOSOME_NOT_FOUND,
 
@@ -759,7 +814,7 @@ enum VariantAnnotationMessage {
    The 'REF' field in the input VCF file does not match the reference genome.
    This warning may indicate a conflict between input data and data from
    reference genome (for instance is the input VCF was aligned to a different
-   reference genome).  Message code W1.
+   reference genome). Message code W1.
    */
   WARNING_REF_DOES_NOT_MATCH_GENOME,
 
@@ -772,14 +827,14 @@ enum VariantAnnotationMessage {
   /**
    A protein coding transcript having a non­multiple of 3 length. It indicates
    that the reference genome has missing information about this particular
-   transcript.  Message code W3.
+   transcript. Message code W3.
    */
   WARNING_TRANSCRIPT_INCOMPLETE,
 
   /**
    A protein coding transcript has two or more STOP codons in the middle of
    the coding sequence (CDS). This should not happen and it usually means the
-   reference genome may have an error in this transcript.  Message code W4.
+   reference genome may have an error in this transcript. Message code W4.
    */
   WARNING_TRANSCRIPT_MULTIPLE_STOP_CODONS,
 
@@ -794,20 +849,20 @@ enum VariantAnnotationMessage {
   /**
    Variant has been realigned to the most 3­prime position within the
    transcript. This is usually done to to comply with HGVS specification
-   to always report the most 3­prime annotation.  Message code I1.
+   to always report the most 3­prime annotation. Message code I1.
    */
   INFO_REALIGN_3_PRIME,
 
   /**
    This effect is a result of combining more than one variants (e.g. two
    consecutive SNPs that conform an MNP, or two consecutive frame_shift
-   variants that compensate frame).  Message code I2.
+   variants that compensate frame). Message code I2.
    */
   INFO_COMPOUND_ANNOTATION,
 
   /**
    An alternative reference sequence was used to calculate this annotation
-   (e.g. cancer sample comparing somatic vs. germline).  Message code I3.
+   (e.g. cancer sample comparing somatic vs. germline). Message code I3.
    */
   INFO_NON_REFERENCE_ANNOTATION
 }
@@ -824,26 +879,26 @@ record TranscriptEffect {
 
   /**
    One or more annotations (also referred to as effects or consequences) of the
-   variant in the context of the feature identified by featureId.  Must be
+   variant in the context of the feature identified by featureId. Must be
    Sequence Ontology (SO, see http://www.sequenceontology.org) term names, e.g.
    stop_gained, missense_variant, synonymous_variant, upstream_gene_variant.
    */
   array<string> effects = [];
 
   /**
-   Common gene name (HGNC), e.g. BRCA2.  May be closest gene if annotation
+   Common gene name (HGNC), e.g. BRCA2. May be closest gene if annotation
    is intergenic.
    */
   union { null, string } geneName = null;
 
   /**
-   Gene identifier, e.g. Ensembl Gene identifier, ENSG00000139618.  May be
+   Gene identifier, e.g. Ensembl Gene identifier, ENSG00000139618. May be
    closest gene if annotation is intergenic.
    */
   union { null, string } geneId = null;
 
   /**
-   Feature type, may use Sequence Ontology term names.  Typically transcript.
+   Feature type, may use Sequence Ontology term names. Typically transcript.
    */
   union { null, string } featureType = null;
 
@@ -853,7 +908,7 @@ record TranscriptEffect {
   union { null, string } featureId = null;
 
   /**
-   Feature biotype, e.g. Protein coding or Non coding.  See http://vega.sanger.ac.uk/info/about/gene_and_transcript_types.html.
+   Feature biotype, e.g. Protein coding or Non coding. See http://vega.sanger.ac.uk/info/about/gene_and_transcript_types.html.
    */
   union { null, string } biotype = null;
 
@@ -868,17 +923,17 @@ record TranscriptEffect {
   union { null, int } total = null;
 
   /**
-   HGVS.g description of the variant.  See http://www.hgvs.org/mutnomen/recs-DNA.html.
+   HGVS.g description of the variant. See http://www.hgvs.org/mutnomen/recs-DNA.html.
    */
   union { null, string } genomicHgvs = null;
 
   /**
-   HGVS.c description of the variant.  See http://www.hgvs.org/mutnomen/recs-DNA.html.
+   HGVS.c description of the variant. See http://www.hgvs.org/mutnomen/recs-DNA.html.
    */
   union { null, string } transcriptHgvs = null;
 
   /**
-   HGVS.p description of the variant, if coding.  See http://www.hgvs.org/mutnomen/recs-prot.html.
+   HGVS.p description of the variant, if coding. See http://www.hgvs.org/mutnomen/recs-prot.html.
    */
   union { null, string } proteinHgvs = null;
 
@@ -939,6 +994,9 @@ record VariantAnnotation {
   array<TranscriptEffect> transcriptEffects = [];
 }
 
+/**
+ Database variant annotations.
+ */
 record DatabaseVariantAnnotation {
   union { null, Variant } variant;
 
@@ -1040,142 +1098,142 @@ record OntologyTerm {
 record Feature {
 
   /**
-   Identifier for this feature.  ID tag in GFF3.
+   Identifier for this feature. ID tag in GFF3.
    */
   union { null, string } featureId = null;
 
   /**
-   Display name for this feature, e.g. DVL1.  Name tag in GFF3, optional column 4 "name"
+   Display name for this feature, e.g. DVL1. Name tag in GFF3, optional column 4 "name"
    in BED format.
    */
   union { null, string } name = null;
 
   /**
    Source of this feature, typically the algorithm or operating procedure that generated
-   this feature, e.g. GeneWise.  Column 2 "source" in GFF3.
+   this feature, e.g. GeneWise. Column 2 "source" in GFF3.
    */
   union { null, string } source = null;
 
   /**
    Feature type, constrained by some formats to a term from the Sequence Ontology (SO),
    e.g. gene, mRNA, exon, or a SO accession number (SO:0000704, SO:0000234, SO:0000147,
-   respectively).  Column 3 "type" in GFF3.
+   respectively). Column 3 "type" in GFF3.
    */
   union { null, string } featureType = null;
 
   /**
-   Contig this feature is located on.  Column 1 "seqid" in GFF3, column 1 "chrom"
+   Contig this feature is located on. Column 1 "seqid" in GFF3, column 1 "chrom"
    in BED format.
    */
   union { null, string } contigName = null;
 
   /**
    Start position for this feature, in 0-based coordinate system with closed-open
-   intervals.  This may require conversion from the coordinate system of the native
-   file format.  Column 4 "start" in GFF3, column 2 "chromStart" in BED format.
+   intervals. This may require conversion from the coordinate system of the native
+   file format. Column 4 "start" in GFF3, column 2 "chromStart" in BED format.
    */
   union { null, long } start = null;
 
   /**
    End position for this feature, in 0-based coordinate system with closed-open
-   intervals.  This may require conversion from the coordinate system of the native
-   file format.  Column 5 "end" in GFF3, column 3 "chromEnd" in BED format.
+   intervals. This may require conversion from the coordinate system of the native
+   file format. Column 5 "end" in GFF3, column 3 "chromEnd" in BED format.
    */
   union { null, long } end = null;
 
   /**
-   Strand for this feature.  Column 7 "strand" in GFF3, optional column 6 "strand"
+   Strand for this feature. Column 7 "strand" in GFF3, optional column 6 "strand"
    in BED format.
    */
   union { null, Strand } strand = null;
 
   /**
    For features of type "CDS", the phase indicates where the feature begins with reference
-   to the reading frame.  The phase is one of the integers 0, 1, or 2, indicating the number
+   to the reading frame. The phase is one of the integers 0, 1, or 2, indicating the number
    of bases that should be removed from the beginning of this feature to reach the first base
-   of the next codon.  Column 8 "phase" in GFF3.
+   of the next codon. Column 8 "phase" in GFF3.
    */
   union { null, int } phase = null;
 
   /**
    For features of type "CDS", the frame indicates whether the first base of the CDS segment is
-   the first (frame 0), second (frame 1) or third (frame 2) in the codon of the ORF.  Column 8
+   the first (frame 0), second (frame 1) or third (frame 2) in the codon of the ORF. Column 8
    "frame" in GFF2/GTF format.
    */
   union { null, int } frame = null;
 
   /**
-   Score for this feature.  Column 6 "score" in GFF3, optional column 5
+   Score for this feature. Column 6 "score" in GFF3, optional column 5
    "score" in BED format.
    */
   union { null, double } score = null;
 
   /**
-   Gene identifier, e.g. ENSG00000107404.  gene_id tag in GFF2/GTF.
+   Gene identifier, e.g. ENSG00000107404. gene_id tag in GFF2/GTF.
    */
   union { null, string } geneId = null;
 
   /**
-   Transcript identifier, e.g. ENST00000378891.  transcript_id tag in GFF2/GTF.
+   Transcript identifier, e.g. ENST00000378891. transcript_id tag in GFF2/GTF.
    */
   union { null, string } transcriptId = null;
 
   /**
-   Exon identifier, e.g. ENSE00001479184.  exon_id tag in GFF2/GTF.
+   Exon identifier, e.g. ENSE00001479184. exon_id tag in GFF2/GTF.
    */
   union { null, string } exonId = null;
 
   /**
-   Secondary names or identifiers for this feature.  Alias tag in GFF3.
+   Secondary names or identifiers for this feature. Alias tag in GFF3.
    */
   array<string> aliases = [];
 
   /**
-   Parent feature identifiers.  Parent tag in GFF3.
+   Parent feature identifiers. Parent tag in GFF3.
    */
   array<string> parentIds = [];
 
   /**
    Target of a nucleotide-to-nucleotide or protein-to-nucleotide alignment
-   feature.  The format of the value is "target_id start end [strand]", where
-   strand is optional and may be "+" or "-".  Target tag in GFF3.
+   feature. The format of the value is "target_id start end [strand]", where
+   strand is optional and may be "+" or "-". Target tag in GFF3.
    */
   union { null, string } target = null;
 
   /**
-   Alignment of the feature to the target in CIGAR format.  Gap tag in GFF3.
+   Alignment of the feature to the target in CIGAR format. Gap tag in GFF3.
    */
   union { null, string } gap = null;
 
   /**
    Used to disambiguate the relationship between one feature and another when
    the relationship is a temporal one rather than a purely structural "part of"
-   one.  Derives_from tag in GFF3.
+   one. Derives_from tag in GFF3.
    */
   union { null, string } derivesFrom = null;
 
   /**
-   Notes or comments for this feature.  Note tag in GFF3.
+   Notes or comments for this feature. Note tag in GFF3.
    */
   array<string> notes = [];
 
   /**
-   Database cross references for this feature.  Dbxref tag in GFF3.
+   Database cross references for this feature. Dbxref tag in GFF3.
    */
   array<Dbxref> dbxrefs = [];
 
   /**
-   Ontology term cross references for this feature.  Ontology_term tag in GFF3.
+   Ontology term cross references for this feature. Ontology_term tag in GFF3.
    */
   array<OntologyTerm> ontologyTerms = [];
 
   /**
-   True if this feature is circular.  Is_circular tag in GFF3.
+   True if this feature is circular. Is_circular tag in GFF3.
    */
-  union { null, boolean } isCircular = null;
+  union { null, boolean } circular = null;
 
   /**
-   Additional feature attributes.  Column 9 "attributes" in GFF3, excepting those
+   Additional feature attributes. Column 9 "attributes" in GFF3, excepting those
    reserved tags parsed into other fields, such as parentIds, dbxrefs, and ontologyTerms.
    */
   map<string> attributes = {};
@@ -1201,7 +1259,7 @@ record Sample {
   union { null, string } name = null;
 
   /**
-   Map of attributes.  Common attributes may include: SRA metadata not mentioned above,
+   Map of attributes. Common attributes may include: SRA metadata not mentioned above,
    e.g. SAMPLE &rarr; TITLE, SAMPLE &rarr; DESCRIPTION, and SAMPLE_ATTRIBUTES; ENA default
    sample checklist attributes such as cell_type, dev_stage, and germline; and Genomes,
    Mixture, and Description from sample meta-information lines in VCF files.


### PR DESCRIPTION
Fixes #100 

Binary incompatible code changes are described by the clirr plugin:
```bash
$ mvn clirr:check
...
[INFO] --- clirr-maven-plugin:2.6.1:check (default-cli) @ bdg-formats ---
[INFO] Comparing to version: 0.9.0
[ERROR] 8001: o.b.f.avro.Base: Class org.bdgenomics.formats.avro.Base removed
[ERROR] 6001: o.b.f.avro.Feature: Removed field isCircular
[ERROR] 7002: o.b.f.avro.Feature: Method 'public java.lang.Boolean getIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature: Method 'public void setIsCircular(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public org.bdgenomics.formats.avro.Feature$Builder clearIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public java.lang.Boolean getIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public boolean hasIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public org.bdgenomics.formats.avro.Feature$Builder setIsCircular(java.lang.Boolean)' has been removed
[ERROR] 6001: o.b.f.avro.Genotype: Removed field isPhased
[ERROR] 7002: o.b.f.avro.Genotype: Method 'public java.lang.Boolean getIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype: Method 'public void setIsPhased(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public org.bdgenomics.formats.avro.Genotype$Builder clearIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public java.lang.Boolean getIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public boolean hasIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public org.bdgenomics.formats.avro.Genotype$Builder setIsPhased(java.lang.Boolean)' has been removed
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field Alt
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field NoCall
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field OtherAlt
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field Ref
[ERROR] 6001: o.b.f.avro.Variant: Removed field isSomatic
[ERROR] 7002: o.b.f.avro.Variant: Method 'public java.lang.Boolean getIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public void setIsSomatic(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder clearIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public java.lang.Boolean getIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public boolean hasIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder setIsSomatic(java.lang.Boolean)' has been removed
```