### PR TITLE
Remove StructuralVariant and StructuralVariantType, add names field to Variant

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -364,145 +364,49 @@ record NucleotideContigFragment {
 }
 
 /**
- Descriptors for the type of a structural variant. The most specific descriptor
- should be used, if possible. E.g., duplication should be used instead of
- insertion if the inserted sequence is not novel. Tandem duplication should
- be used instead of duplication if the duplication is known to follow the
- duplicated sequence.
- */
-enum StructuralVariantType {
-
-  /**
-   Breakend.  VCF INFO reserved key "SVTYPE" value "BND".
-   */
-  BREAKEND,
-
-  /**
-   Copy number variable region (may be both deletion and duplication).
-   VCF INFO reserved key "SVTYPE" value "CNV".
-   */
-  COPY_NUMBER_VARIABLE,
-
-  /**
-   Deletion relative to the reference. VCF INFO reserved key "SVTYPE" value "DEL".
-   */
-  DELETION,
-
-  /**
-   Region of elevated copy number relative to the reference.
-   VCF INFO reserved key "SVTYPE" value "DUP".
-   */
-  DUPLICATION,
-
-  /**
-   Insertion of novel sequence relative to the reference.
-   VCF INFO reserved key "SVTYPE" value "INS".
-   */
-  INSERTION,
-
-  /**
-   Inversion of reference sequence. VCF INFO reserved key "SVTYPE" value "INV".
-   */
-  INVERSION,
-
-  /**
-   Insertion of a mobile element relative to the reference.
-   VCF INFO reserved key "SVTYPE" value "INS:ME".
-   */
-  MOBILE_INSERTION,
-
-  /**
-   Deletion of mobile element relative to the reference.
-   VCF INFO reserved key "SVTYPE" value "DEL:ME".
-   */
-  MOBILE_DELETION,
-
-  /**
-   Tandem duplication. VCF INFO reserved key "SVTYPE" value "DUP:TANDEM".
-   */
-  TANDEM_DUPLICATION
-}
-
-/**
- Structural variant.
- */
-record StructuralVariant {
-
-  /**
-   The type of this structural variant.
-   */
-  union { null, StructuralVariantType } type = null;
-
-  /**
-   The URL of the FASTA/NucleotideContig assembly for this structural variant,
-   if one is available.
-   */
-  union { null, string } assembly = null;
-
-  /**
-   Whether this structural variant call has precise breakpoints or not. Default
-   value is true. If the call is imprecise, confidence intervals should be provided.
-   */
-  union { boolean, null } precise = true;
-
-  /**
-   The size of the confidence window around the start of the structural variant.
-   */
-  union { null, int } startWindow = null;
-
-  /**
-   The size of the confidence window around the end of the structural variant.
-   */
-  union { null, int } endWindow = null;
-}
-
-/**
  Variant.
  */
 record Variant {
 
   /**
-   The Phred scaled error probability of a variant, given the probabilities of
-   the variant in a population.
-   */
-  union { null, int } variantErrorProbability = null;
-
-  /**
-   The reference contig that this variant exists on.
+   The reference contig this variant exists on. VCF column 1 "CONTIG".
    */
   union { null, string } contigName = null;
 
   /**
-   The 0-based start position of this variant on the reference contig.
+   The zero-based start position of this variant on the reference contig.
+   VCF column 2 "POS" converted to zero-based coordinate system, closed-open intervals.
    */
   union { null, long } start = null;
 
   /**
-   The 0-based, exclusive end position of this variant on the reference contig.
+   The zero-based, exclusive end position of this variant on the reference contig.
+   Calculated by start + referenceAllele.length().
    */
   union { null, long } end = null;
 
   /**
-   A string describing the reference allele at this site.
+   Zero or more unique names or identifiers for this variant. If this is a dbSNP
+   variant it is encouraged to use the rs number(s). VCF column 3 "ID" copied for
+   multi-allelic sites.
+   */
+  array<string> names = [];
+
+  /**
+   A string describing the reference allele at this site. VCF column 4 "REF".
    */
   union { null, string } referenceAllele = null;
 
   /**
-   A string describing the variant allele at this site. Should be left null if
-   the site is a structural variant.
+   A string describing the alternate allele at this site. VCF column 5 "ALT" split
+   for multi-allelic sites.
    */
   union { null, string } alternateAllele = null;
 
   /**
-   The structural variant at this site, if the alternate allele is a structural
-   variant. If the site is not a structural variant, this field should be left
-   null.
-   */
-  union { null, StructuralVariant } svAllele = null;
-
-  /**
-   A boolean describing whether this variant call is somatic; in this case, the
-   referenceAllele will have been observed in another sample.
+   True if this variant call is somatic; in this case, the referenceAllele will
+   have been observed in another sample. VCF INFO reserved key "SOMATIC" copied
+   for multi-allelic sites.
    */
   union { boolean, null } somatic = false;
 }


### PR DESCRIPTION
Fixes #102 

Binary incompatible code changes since 0.9.0:
```bash
$ mvn clirr:check
...
[INFO] --- clirr-maven-plugin:2.6.1:check (default-cli) @ bdg-formats ---
[INFO] Comparing to version: 0.9.0
[ERROR] 8001: o.b.f.avro.Base: Class o.b.f.avro.Base removed
[ERROR] 6001: o.b.f.avro.Feature: Removed field isCircular
[ERROR] 7002: o.b.f.avro.Feature: Method 'public java.lang.Boolean getIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature: Method 'public void setIsCircular(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public o.b.f.avro.Feature$Builder clearIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public java.lang.Boolean getIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public boolean hasIsCircular()' has been removed
[ERROR] 7002: o.b.f.avro.Feature$Builder: Method 'public o.b.f.avro.Feature$Builder setIsCircular(java.lang.Boolean)' has been removed
[ERROR] 6001: o.b.f.avro.Genotype: Removed field isPhased
[ERROR] 7002: o.b.f.avro.Genotype: Method 'public java.lang.Boolean getIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype: Method 'public void setIsPhased(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public o.b.f.avro.Genotype$Builder clearIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public java.lang.Boolean getIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public boolean hasIsPhased()' has been removed
[ERROR] 7002: o.b.f.avro.Genotype$Builder: Method 'public o.b.f.avro.Genotype$Builder setIsPhased(java.lang.Boolean)' has been removed
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field Alt
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field NoCall
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field OtherAlt
[ERROR] 6001: o.b.f.avro.GenotypeAllele: Removed field Ref
[ERROR] 8001: o.b.f.avro.StructuralVariant: Class o.b.f.avro.StructuralVariant removed
[ERROR] 8001: o.b.f.avro.StructuralVariant$Builder: Class o.b.f.avro.StructuralVariant$Builder removed
[ERROR] 8001: o.b.f.avro.StructuralVariantType: Class o.b.f.avro.StructuralVariantType removed
[ERROR] 6001: o.b.f.avro.Variant: Removed field isSomatic
[ERROR] 6001: o.b.f.avro.Variant: Removed field svAllele
[ERROR] 6001: o.b.f.avro.Variant: Removed field variantErrorProbability
[ERROR] 7004: o.b.f.avro.Variant: In method 'public Variant(java.lang.Integer, java.lang.String, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, o.b.f.avro.StructuralVariant, java.lang.Boolean)' the number of arguments has changed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public java.lang.Boolean getIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public o.b.f.avro.StructuralVariant getSvAllele()' has been removed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public java.lang.Integer getVariantErrorProbability()' has been removed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public void setIsSomatic(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public void setSvAllele(o.b.f.avro.StructuralVariant)' has been removed
[ERROR] 7002: o.b.f.avro.Variant: Method 'public void setVariantErrorProbability(java.lang.Integer)' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder clearIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder clearSvAllele()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder clearVariantErrorProbability()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public java.lang.Boolean getIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.StructuralVariant getSvAllele()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.StructuralVariant$Builder getSvAlleleBuilder()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public java.lang.Integer getVariantErrorProbability()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public boolean hasIsSomatic()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public boolean hasSvAllele()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public boolean hasSvAlleleBuilder()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public boolean hasVariantErrorProbability()' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder setIsSomatic(java.lang.Boolean)' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder setSvAllele(o.b.f.avro.StructuralVariant)' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder setSvAlleleBuilder(o.b.f.avro.StructuralVariant$Builder)' has been removed
[ERROR] 7002: o.b.f.avro.Variant$Builder: Method 'public o.b.f.avro.Variant$Builder setVariantErrorProbability(java.lang.Integer)' has been removed
```