### PR TITLE
Merge VariantAnnotation and DatabaseVariantAnnotation records

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -387,8 +387,8 @@ record Variant {
 
   /**
    Zero or more unique names or identifiers for this variant. If this is a dbSNP
-   variant it is encouraged to use the rs number(s). VCF column 3 "ID" copied for
-   multi-allelic sites.
+   variant it is encouraged to use the rs number(s). VCF column 3 "ID" shared across
+   all alleles in the same VCF record.
    */
   array<string> names = [];
 
@@ -405,8 +405,9 @@ record Variant {
 
   /**
    True if this variant call is somatic; in this case, the referenceAllele will
-   have been observed in another sample. VCF INFO reserved key "SOMATIC" copied
-   for multi-allelic sites.
+   have been observed in another sample. VCF INFO reserved key "SOMATIC", Number=0.
+   Until Number=A and Number=R flags are supported by the VCF specification, this value
+   is shared across all alleles in the same VCF record.
    */
   union { boolean, null } somatic = false;
 }
@@ -883,57 +884,107 @@ record TranscriptEffect {
 }
 
 /**
- Annotations of a variant, as produced by a tool such as SnpEff or Ensembl VEP.
+ Variant annotation.
  */
 record VariantAnnotation {
 
   /**
    Variant for this annotation.
    */
-  union { null, Variant } variant;
+  union { null, Variant } variant = null;
 
   /**
-   Zero or more transcript effects, per alternate allele and transcript (or other feature).
+   Ancestral allele, VCF INFO reserved key AA, Number=1, shared across all alleles
+   in the same VCF record.
+   */
+  union { null, string } ancestralAllele = null;
+
+  /**
+   Allele count, VCF INFO reserved key AC, Number=A, split for multi-allelic sites.
+   */
+  union { null, int } alleleCount = null;
+
+  /**
+   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
+   sites.
+   */
+  union { null, int } readDepth = null;
+
+  /**
+   Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
+   multi-allelic sites.
+   */
+  union { null, int } forwardReadDepth = null;
+
+  /**
+   Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
+   multi-allelic sites.
+   */
+  union { null, int } reverseReadDepth = null;
+
+  /**
+   Minor allele frequency, VCF INFO reserved key AF, Number=A, split for multi-allelic
+   sites. Use this when frequencies are estimated from primary data, not calculated
+   from called genotypes.
+   */
+  union { null, float } alleleFrequency = null;
+
+  /**
+   CIGAR string describing how to align an alternate allele to the reference
+   allele, VCF INFO reserved key CIGAR, Number=A, split for multi-allelic sites.
+   */
+  union { null, string } cigar = null;
+
+  /**
+   Membership in dbSNP, VCF INFO reserved key DB, Number=0. Until Number=A and
+   Number=R flags are supported by the VCF specification, this value is shared
+   across all alleles in the same VCF record.
+   */
+  union { null, boolean } dbSnp = null;
+
+  /**
+   Membership in HapMap2, VCF INFO reserved key H2, Number=0. Until Number=A and
+   Number=R flags are supported by the VCF specification, this value is shared
+   across all alleles in the same VCF record.
+   */
+  union { null, boolean } hapMap2 = null;
+
+  /**
+   Membership in HapMap3, VCF INFO reserved key H3, Number=0. Until Number=A and
+   Number=R flags are supported by the VCF specification, this value is shared
+   across all alleles in the same VCF record.
+   */
+  union { null, boolean } hapMap3 = null;
+
+  /**
+   Validated by follow up experiment, VCF INFO reserved key VALIDATED, Number=0.
+   Until Number=A and Number=R flags are supported by the VCF specification, this
+   value is shared across all alleles in the same VCF record.
+   */
+  union { null, boolean } validated = null;
+
+  /**
+   Membership in 1000 Genomes, VCF INFO reserved key 1000G, Number=0. Until
+   Number=A and Number=R flags are supported by the VCF specification, this
+   value is shared across all alleles in the same VCF record.
+   */
+  union { null, boolean } thousandGenomes = null;
+
+  /**
+   Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
+   one per transcript (or other feature).  VCF INFO header key ANN, split for multi-allelic
+   sites.  See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
    */
   array<TranscriptEffect> transcriptEffects = [];
-}
 
-/**
- Database variant annotations.
- */
-record DatabaseVariantAnnotation {
-  union { null, Variant } variant;
-
-  union { null, int } dbSnpId = null;
-
-  //domain information
-  union {null, string} geneSymbol = null;
-
-  //clinical fields
-  union {null, string} omimId  = null;
-  union {null, string} cosmicId = null;
-  union {null, string} clinvarId  = null;
-  union {null, string} clinicalSignificance  = null;
-
-  //conservation
-  union { null, string } gerpNr  = null;
-  union { null, string } gerpRs  = null;
-  union { null, float } phylop  = null;
-  union { null, string } ancestralAllele  = null;
-
-  //population statistics
-  union {null, int} thousandGenomesAlleleCount = null;
-  union {null, float} thousandGenomesAlleleFrequency = null;
-
-  //predicted effects
-  union { null, float } siftScore = null;
-  union { null, float } siftScoreConverted = null;
-  union { null, string } siftPred = null;
-
-  union { null, float } mutationTasterScore = null;
-  union { null, float } mutationTasterScoreConverted = null;
-  union { null, string } mutationTasterPred = null;
-
+  /**
+   Additional variant attributes that do not fit into the standard fields above.
+   The values are stored as strings, even for flag, integer, and float types.  VCF
+   INFO key values with Number=., Number=0, Number=1, and Number=[n] are shared across
+   all alleles in the same VCF record. VCF INFO key values with Number=A and Number=R
+   are split for multi-allelic sites.
+   */
+  map<string> attributes = {};
 }
 
 /**


### PR DESCRIPTION
* Merge `VariantAnnotation` and `DatabaseVariantAnnotation` records into `VariantAnnotation`
* Align record fields more closely with VCF INFO reserved keys from VCF v4.3 specification
* Document where fields are shared across all alleles in the same VCF record or split for multi-allelic sites
* Document issue with flags for multi-allelic sites in VCF specification, i.e. flags are currently defined as Number=0, whereas they should be Number=A or Number=R

For review:
- [x] Fields that don't appear to make sense for our split allele model are documented and commented out in this commit
- [x] For non-reserved VCF INFO keys, should those with Number=A or Number=R be split for multi-allelic sites before storing in the `attributes` field?
- [x] VCF INFO reserved key "END" can be used to define the end position for symbolic alleles.  Should we support setting `Variant.end` field from this value or store it in `attributes`?
- [x] Are there any non-reserved VCF INFO keys that we should add support for at the field level?

Draft documentation for mapping is here
https://github.com/heuermh/bdg-formats/blob/docs/docs/source/variants.md

```
$ mvn clirr:check
...
[INFO] --- clirr-maven-plugin:2.6.1:check (default-cli) @ bdg-formats ---
[INFO] Comparing to version: 0.9.0
[ERROR] 8001: org.bdgenomics.formats.avro.Base: Class org.bdgenomics.formats.avro.Base removed
[ERROR] 8001: org.bdgenomics.formats.avro.DatabaseVariantAnnotation: Class org.bdgenomics.formats.avro.DatabaseVariantAnnotation removed
[ERROR] 8001: org.bdgenomics.formats.avro.DatabaseVariantAnnotation$Builder: Class org.bdgenomics.formats.avro.DatabaseVariantAnnotation$Builder removed
[ERROR] 6001: org.bdgenomics.formats.avro.Feature: Removed field isCircular
[ERROR] 7002: org.bdgenomics.formats.avro.Feature: Method 'public java.lang.Boolean getIsCircular()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Feature: Method 'public void setIsCircular(java.lang.Boolean)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Feature$Builder: Method 'public org.bdgenomics.formats.avro.Feature$Builder clearIsCircular()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Feature$Builder: Method 'public java.lang.Boolean getIsCircular()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Feature$Builder: Method 'public boolean hasIsCircular()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Feature$Builder: Method 'public org.bdgenomics.formats.avro.Feature$Builder setIsCircular(java.lang.Boolean)' has been removed
[ERROR] 6001: org.bdgenomics.formats.avro.Genotype: Removed field isPhased
[ERROR] 7002: org.bdgenomics.formats.avro.Genotype: Method 'public java.lang.Boolean getIsPhased()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Genotype: Method 'public void setIsPhased(java.lang.Boolean)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Genotype$Builder: Method 'public org.bdgenomics.formats.avro.Genotype$Builder clearIsPhased()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Genotype$Builder: Method 'public java.lang.Boolean getIsPhased()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Genotype$Builder: Method 'public boolean hasIsPhased()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Genotype$Builder: Method 'public org.bdgenomics.formats.avro.Genotype$Builder setIsPhased(java.lang.Boolean)' has been removed
[ERROR] 6001: org.bdgenomics.formats.avro.GenotypeAllele: Removed field Alt
[ERROR] 6001: org.bdgenomics.formats.avro.GenotypeAllele: Removed field NoCall
[ERROR] 6001: org.bdgenomics.formats.avro.GenotypeAllele: Removed field OtherAlt
[ERROR] 6001: org.bdgenomics.formats.avro.GenotypeAllele: Removed field Ref
[ERROR] 8001: org.bdgenomics.formats.avro.StructuralVariant: Class org.bdgenomics.formats.avro.StructuralVariant removed
[ERROR] 8001: org.bdgenomics.formats.avro.StructuralVariant$Builder: Class org.bdgenomics.formats.avro.StructuralVariant$Builder removed
[ERROR] 8001: org.bdgenomics.formats.avro.StructuralVariantType: Class org.bdgenomics.formats.avro.StructuralVariantType removed
[ERROR] 6001: org.bdgenomics.formats.avro.Variant: Removed field isSomatic
[ERROR] 6001: org.bdgenomics.formats.avro.Variant: Removed field svAllele
[ERROR] 6001: org.bdgenomics.formats.avro.Variant: Removed field variantErrorProbability
[ERROR] 7004: org.bdgenomics.formats.avro.Variant: In method 'public Variant(java.lang.Integer, java.lang.String, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, org.bdgenomics.formats.avro.StructuralVariant, java.lang.Boolean)' the number of arguments has changed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant: Method 'public java.lang.Boolean getIsSomatic()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant: Method 'public org.bdgenomics.formats.avro.StructuralVariant getSvAllele()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant: Method 'public java.lang.Integer getVariantErrorProbability()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant: Method 'public void setIsSomatic(java.lang.Boolean)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant: Method 'public void setSvAllele(org.bdgenomics.formats.avro.StructuralVariant)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant: Method 'public void setVariantErrorProbability(java.lang.Integer)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder clearIsSomatic()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder clearSvAllele()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder clearVariantErrorProbability()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public java.lang.Boolean getIsSomatic()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.StructuralVariant getSvAllele()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.StructuralVariant$Builder getSvAlleleBuilder()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public java.lang.Integer getVariantErrorProbability()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public boolean hasIsSomatic()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public boolean hasSvAllele()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public boolean hasSvAlleleBuilder()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public boolean hasVariantErrorProbability()' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder setIsSomatic(java.lang.Boolean)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder setSvAllele(org.bdgenomics.formats.avro.StructuralVariant)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder setSvAlleleBuilder(org.bdgenomics.formats.avro.StructuralVariant$Builder)' has been removed
[ERROR] 7002: org.bdgenomics.formats.avro.Variant$Builder: Method 'public org.bdgenomics.formats.avro.Variant$Builder setVariantErrorProbability(java.lang.Integer)' has been removed
[ERROR] 7004: org.bdgenomics.formats.avro.VariantAnnotation: In method 'public VariantAnnotation(org.bdgenomics.formats.avro.Variant, java.util.List)' the number of arguments has changed
```
