### PR TITLE
Refactor Genotype and GenotypeAnnotation

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -990,29 +990,33 @@ record GenotypeAnnotation {
 record Genotype {
 
   /**
-   The variant for this genotype. May be left unset or set to null for performance reasons.
-   */
-  union { null, Variant } variant = null;
-
-  /**
    The reference contig the variant for this genotype exists on. VCF column 1 "CONTIG".
-   Used when the variant field has been left unset or set to null for performance reasons.
    */
   union { null, string } contigName = null;
 
   /**
    The zero-based start position of the variant for this genotype on the reference contig.
    VCF column 2 "POS" converted to zero-based coordinate system, closed-open intervals.
-   Used when the variant field has been left unset or set to null for performance reasons.
    */
   union { null, long } start = null;
 
   /**
    The zero-based, exclusive end position of the variant for this genotype on the reference
-   contig. Calculated by Variant.start + Variant.referenceAllele.length(). Used when the
-   variant field has been left unset or set to null for performance reasons.
+   contig. Calculated by start + referenceAllele.length().
    */
   union { null, long } end = null;
+
+  /**
+   A string describing the reference allele of the variant for this genotype.
+   VCF column 4 "REF".
+   */
+  union { null, string } referenceAllele = null;
+
+  /**
+   A string describing the alternate allele of the variant for this genotype.
+   VCF column 5 "ALT" split for multi-allelic sites.
+   */
+  union { null, string } alternateAllele = null;
 
   /**
    Sample identifier for this genotype. Join with Sample.sampleId for sample metadata.

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -800,166 +800,71 @@ record Variant {
 }
 
 /**
- An enumeration that describes the allele that corresponds to a genotype.
+ Allele encodings for genotypes.
  */
-enum GenotypeAllele {
+enum Allele {
 
   /**
-   The genotype is the reference allele.
+   Reference allele.
    */
   REF,
 
   /**
-   The genotype is the alternate allele.
+   Alternate allele.
    */
   ALT,
 
   /**
-   The genotype is an unspecified other alternate allele. This occurs in our schema
-   when we have split a multi-allelic genotype into two genotype records.
+   An unspecified other alternate allele. This may occur when the variant for
+   the genotype partially encoded by this allele is split as a multi-allelic site.
    */
   OTHER_ALT,
 
   /**
-   The genotype could not be called.
+   Missing allele.
    */
   NO_CALL
 }
 
 /**
- An enumeration that describes the characteristics of a genotype at a site.
+ Genotype annotation.
  */
-enum GenotypeType {
+record GenotypeAnnotation {
 
   /**
-   All genotypes at this site were called as the reference allele.
+   Conditional genotype quality, encoded as a phred quality −10log10 p(genotype call is wrong
+   conditioned on the site being variant). VCF genotype field reserved key GQ.
    */
-  HOM_REF,
+  union { null, int } genotypeQuality = null;
 
   /**
-   Genotypes at this site were called as multiple different alleles. This
-   most commonly occurs if a diploid sample's genotype contains one reference
-   and one variant allele, but can also occur if the genotype contains multiple
-   alternate alleles.
+   Haplotype quality, encoded as two phred qualities. VCF genotype field reserved key HQ.
    */
-  HET,
+  array<int> haplotypeQuality = [];
 
   /**
-   All genotypes at this site were called as a single alternate allele.
+   Phred-scaled probability that alleles are ordered incorrectly, against all other members in
+   the same phase set. VCF genotype field reserved key PQ.
    */
-  HOM_ALT,
+  union { null, int } phaseSetQuality = null;
 
   /**
-   The genotype could not be called at this site.
+   Root Mean Square (RMS) of the mapping quality of reads for this genotype. VCF genotype field
+   reserved key MQ.
    */
-  NO_CALL
-}
-
-/**
- This record represents all stats that, inside a VCF, are stored outside of the
- sample but are computed based on the samples. For instance, MAPQ0 is an aggregate
- stat computed from all samples and stored inside the INFO line.
- */
-record VariantCallingAnnotations {
+  union { null, int } rmsMappingQuality = null;
 
   /**
-   True if filters were applied for this genotype call. FORMAT field "FT" any value other
-   than the missing value.
+   Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.
+   If set, the array should contain the number of reads that support the reference allele on the
+   forward strand, the reference allele on the reverse strand, the alternate allele on the forward
+   strand, and the alternate allele on the reverse strand, in that order. VCF genotype field key SB.
    */
-  union { null, boolean } filtersApplied = null;
+  array<int> strandBias = [];
 
   /**
-   True if all filters for this genotype call passed. FORMAT field "FT" value PASS.
-   */
-  union { null, boolean } filtersPassed = null;
-
-  /**
-   Zero or more filters that failed for this genotype call from FORMAT field "FT".
-   */
-  array<string> filtersFailed = [];
-
-  /**
-   True if the reads covering this site were randomly downsampled to reduce coverage.
-   */
-  union { null, boolean } downsampled = null;
-
-  /**
-   The Wilcoxon rank-sum test statistic of the base quality scores. The base quality
-   scores are separated by whether or not the base supports the reference or the
-   alternate allele.
-   */
-  union { null, float } baseQRankSum = null;
-
-  /**
-   The Fisher's exact test score for the strand bias of the reference and alternate
-   alleles. Stored as a phred scaled probability. Thus, if:
-
-   * a = The number of positive strand reads covering the reference allele
-   * b = The number of positive strand reads covering the alternate allele
-   * c = The number of negative strand reads covering the reference allele
-   * d = The number of negative strand reads covering the alternate allele
-
-   This value takes the score:
-   
-   -10 log((a + b)! * (c + d)! * (a + c)! * (b + d)! / (a! b! c! d! n!)
-
-   Where n = a + b + c + d.
-   */
-  union { null, float } fisherStrandBiasPValue = null;
-
-  /**
-   The root mean square of the mapping qualities of reads covering this site.
-   */
-  union { null, float } rmsMapQ = null;
-  
-  /**
-   The number of reads at this site with mapping quality equal to 0.
-   */
-  union { null, int } mapq0Reads = null;
-
-  /**
-   The Wilcoxon rank-sum test statistic of the mapping quality scores. The mapping
-   quality scores are separated by whether or not the read supported the reference or the
-   alternate allele.
-   */
-  union { null, float } mqRankSum = null;
-
-  /**
-   The Wilcoxon rank-sum test statistic of the position of the base in the read at this site.
-   The positions are separated by whether or not the base supports the reference or the
-   alternate allele.
-   */
-  union { null, float } readPositionRankSum = null;
-
-  /**
-   The log scale prior probabilities of the various genotype states at this site.
-   The number of elements in this array should be equal to the ploidy at this
-   site, plus 1.
-   */
-  array<float> genotypePriors = [];
-
-  /**
-   The log scaled posterior probabilities of the various genotype states at this site,
-   in this sample. The number of elements in this array should be equal to the ploidy at
-   this site, plus 1.
-   */
-  array<float> genotypePosteriors = [];
-
-  /**
-   The log-odds ratio of being a true vs. false variant under a trained statistical model.
-   This model can be a multivariate Gaussian mixture, support vector machine, etc.
-   */
-  union { null, float } vqslod = null;
-
-  /**
-   If known, the feature that contributed the most to this variant being classified as
-   a false variant.
-   */
-  union { null, string } culprit = null;
-
-  /**
-   Additional feature info that doesn't fit into the standard fields above.
-   They are all encoded as (string, string) key-value pairs.
+   Additional genotype attributes that do not fit into the standard fields above.
+   The values are stored as strings, even for flag, integer, and float types.
    */
   map<string> attributes = {};
 }
@@ -970,129 +875,76 @@ record VariantCallingAnnotations {
 record Genotype {
 
   /**
-   The variant called at this site.
+   The variant for this genotype.
    */
   union { null, Variant } variant = null;
 
   /**
-   The reference contig that this genotype's variant exists on.
+   The reference contig the variant for this genotype exists on. VCF column 1 "CONTIG".
+   Used when the variant field has been left unset or set to null for performance reasons.
    */
   union { null, string } contigName = null;
 
   /**
-   The 0-based start position of this genotype's variant on the reference contig.
+   The zero-based start position of the variant for this genotype on the reference contig.
+   VCF column 2 "POS" converted to zero-based coordinate system, closed-open intervals.
+   Used when the variant field has been left unset or set to null for performance reasons.
    */
   union { null, long } start = null;
 
   /**
-   The 0-based, exclusive end position of this genotype's variant on the reference contig.
+   The zero-based, exclusive end position of the variant for this genotype on the reference
+   contig. Calculated by Variant.start + Variant.referenceAllele.length(). Used when the
+   variant field has been left unset or set to null for performance reasons.
    */
   union { null, long } end = null;
 
   /**
-   Statistics collected at this site, if available.
+   Sample identifier for this genotype. Join with Sample.sampleId for sample metadata.
+   VCF header line sample id.
    */
-  union { null, VariantCallingAnnotations } variantCallingAnnotations = null;
+  union { null, string } sampleId = null;
 
   /**
-   The unique identifier for this sample.
+   One or more allele values encoding this genotype. If this genotype is phased, the order of
+   the allele values is significant. VCF genotype field reserved key GT mapped to Allele enum
+   values.
    */
-  union { null, string }  sampleId = null;
+  array<Allele> alleles = [];
 
   /**
-   A description of this sample.
-   */
-  union { null, string }  sampleDescription = null;
-
-  /**
-   A string describing the provenance of this sample and the processing applied
-   in genotyping this sample.
-   */
-  union { null, string }  processingDescription = null;
-
-  /**
-   An array describing the genotype called at this site. The length of this
-   array is equal to the ploidy of the sample at this site. This array may
-   reference OTHER_ALT alleles if this site is multi-allelic in this sample.
-   */
-  array<GenotypeAllele> alleles = [];
-
-  /**
-   The expected dosage of the alternate allele in this sample.
-   */
-  union { null, float } expectedAlleleDosage = null;
-
-  /**
-   The number of reads that show evidence for the reference at this site.
-   */
-  union { null, int } referenceReadDepth = null;
-
-  /**
-   The number of reads that show evidence for this alternate allele at this site.
-   */
-  union { null, int } alternateReadDepth = null;
-
-  /**
-   The total number of reads at this site. May not equal (alternateReadDepth +
-   referenceReadDepth) if this site shows evidence of multiple alternate alleles.
-   Analogous to VCF's DP.
-   */
-  union { null, int } readDepth = null;
-
-  /**
-   The minimum number of reads seen at this site across samples when joint
-   calling variants. Analogous to VCF's MIN_DP.
-   */
-  union { null, int } minReadDepth = null;
-
-  /**
-   The phred-scaled probability that we're correct for this genotype call.
-   Analogous to VCF's GQ.
-   */
-  union { null, int } genotypeQuality = null;
-
-  /**
-   Log scaled likelihoods that we have n copies of this alternate allele.
-   The number of elements in this array should be equal to the ploidy at this
-   site, plus 1. Analogous to VCF's PL.
-   */
-  array<double> genotypeLikelihoods = [];
-
-  /**
-   Log scaled likelihoods that we have n non-reference alleles at this site.
-   The number of elements in this array should be equal to the ploidy at this
-   site, plus 1.
-   */
-  array<double> nonReferenceLikelihoods = [];
-
-  /**
-   Component statistics which comprise the Fisher's Exact Test to detect strand bias.
-   If populated, this element should have length 4.
-   */
-  array<int> strandBiasComponents = [];
-
-  /**
-   We split multi-allelic VCF lines into multiple single-alternate records.
-   This bit is set if that happened for this record.
-   */
-  union { boolean, null } splitFromMultiAllelic = false;
-
-  /**
-   True if this genotype is phased.
+   True if this genotype is phased. If true, the order of alleles is significant. VCF genotype field
+   reserved key GT allele separators: '|' genotype is phased; '/' genotype is unphased.
    */
   union { boolean, null } phased = false;
 
   /**
-   The ID of this phase set, if this genotype is phased. Should only be populated
-   if phased == true; else should be null.
+   Phase set identifier, if any. Phased genotypes on the same contig with the same phaseSetId
+   are in the same phased set. All phased genotypes that do not have a phaseSetId are assumed to
+   belong to the same phased set. VCF genotype field reserved key PS.
    */
   union { null, int } phaseSetId = null;
 
   /**
-   Phred scaled quality score for the phasing of this genotype, if this genotype
-   is phased. Should only be populated if phased == true; else should be null.
+   True if filters were applied for this genotype. VCF genotype field reserved key FT any
+   value other than the missing value.
    */
-  union { null, int } phaseQuality = null;
+  union { null, boolean } filtersApplied = null;
+
+  /**
+   True if all filters for this genotype passed. VCF genotype field reserved key FT value PASS.
+   */
+  union { null, boolean } filtersPassed = null;
+
+  /**
+   Zero or more filters that failed for this genotype. VCF genotype field reserved key FT.
+   */
+  array<string> filtersFailed = [];
+
+  /**
+   Annotation for this genotype, if any.
+   */
+  union { null, GenotypeAnnotation } annotation = null;
 }
 
 /**

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -879,15 +879,6 @@ record GenotypeAnnotation {
    */
   union { null, int } readDepth = null;
 
-  // EC Number=A Type=Integer
-  // Comma separated list of expected alternate allele counts for each alternate allele in the same
-  // order as listed in the ALT field. Typically used in association analyses.
-  /**
-   The expected dosage of the alternate allele in this sample. VCF genotype reserved key EC,
-   Number=A, split for multi-allelic sites into a single float value.
-   */
-  union { null, float } expectedAlleleDosage = null; // or expectedAlleleCount? see Variant.alleleCount
-
   // GL Number=G Type=Float
   /**
    Genotype likelihoods comprised of floating point log10-scaled likelihoods for all possible
@@ -895,10 +886,6 @@ record GenotypeAnnotation {
    reserved key GL, Number=G.
    */
   array<float> likelihoods = [];
-
-  // GLE Number=1 Type=String
-  // Genotype likelihoods of heterogeneous ploidy, used in presence of uncertain copy number.
-  // Reserved genotype field key in VCF v4.2, dropped in VCF v4.3
 
   // GP Number=G Type=Float
   /**
@@ -915,25 +902,12 @@ record GenotypeAnnotation {
    */
   union { null, int } quality = null;
 
-  // HQ Number=2 Type=Integer
-  /**
-   Haplotype quality, encoded as two phred qualities. VCF genotype field reserved key HQ, Number=2.
-   */
-  array<int> haplotypeQuality = [];
-
   // MQ Number=1 Type=Integer
   /**
    Root Mean Square (RMS) of the mapping quality of reads for this genotype. VCF genotype field
    reserved key MQ.
    */
   union { null, int } rmsMappingQuality = null;
-
-  // PL Number=G Type=Integer
-  /**
-   Phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined precisely
-   as the genotype likelihoods field. VCF genotype field reserved key PL, Number=G.
-   */
-  array<int> phredScaledLikelihoods = [];
 
   // PQ Number=1 Type=Integer
   /**
@@ -942,47 +916,39 @@ record GenotypeAnnotation {
    */
   union { null, int } phaseSetQuality = null;
 
-
-  // SB is not a reserved key in VCF v4.2 or v4.3
-  /**
-   Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.
-   If set, the array should contain the number of reads that support the reference allele on the
-   forward strand, the reference allele on the reverse strand, the alternate allele on the forward
-   strand, and the alternate allele on the reverse strand, in that order. VCF genotype field key SB.
-   */
-  //array<int> strandBias = [];  Genotype.strandBiasComponents previously
-
-
   //
   // Not present in VCF specification yet present in Genotype
 
-  // The minimum number of reads seen at this site across samples when joint calling variants.
-  // Analogous to VCF's MIN_DP.
-  //union { null, int } minReadDepth = null;
+  /**
+   Minimum number of reads seen at this site across samples when joint calling variants.
+   VCF genotype field key MIN_DP.
+   */
+  union { null, int } minimumReadDepth = null;
 
-  // Log scaled likelihoods that we have n non-reference alleles at this site. The number of
-  // elements in this array should be equal to the ploidy at this site, plus 1.
-  //array<float> nonReferenceLikelihoods = [];
-
-  // We split multi-allelic VCF lines into multiple single-alternate records. This bit is set
-  // if that happened for this record.
-  //union { boolean, null } splitFromMultiAllelic = false;
+  /**
+   Log scaled likelihoods that we have n non-reference alleles at this site. The number of
+   elements in this array should be equal to the ploidy at this site, plus 1.
+   */
+  array<float> nonReferenceLikelihoods = [];
 
 
   //
   // Not present in VCF specification yet present in VariantCallingAnnotations
 
-  // True if the reads covering this site were randomly downsampled to reduce coverage.
-  //union { null, boolean } downsampled = null;
+  /**
+   True if the reads covering this site were randomly downsampled to reduce coverage.
+   */
+  union { null, boolean } downsampled = null;
 
   // The Wilcoxon rank-sum test statistic of the base quality scores. The base quality
   // scores are separated by whether or not the base supports the reference or the
   // alternate allele.
   //union { null, float } baseQRankSum = null;
 
-  // The Fisher's exact test score for the strand bias of the reference and alternate
-  // alleles.
-  //union { null, float } fisherStrandBiasPValue = null;
+  /**
+   Fisher's exact test score for the strand bias of the reference and alternate alleles.
+   */
+  union { null, float } fisherStrandBiasPValue = null;
 
   // The number of reads at this site with mapping quality equal to 0.
   //union { null, int } mapq0Reads = null;
@@ -1093,6 +1059,11 @@ record Genotype {
    Zero or more filters that failed for this genotype. VCF genotype field reserved key FT.
    */
   array<string> filtersFailed = [];
+
+  /**
+   True if this genotype was split from a multi-allelic site in VCF.
+   */
+  union { boolean, null } splitFromMultiAllelic = false;
 
   /**
    Annotation for this genotype, if any.

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -595,61 +595,61 @@ record TranscriptEffect {
 record VariantAnnotation {
 
   /**
-   Ancestral allele, VCF INFO reserved key AA, Number=1, shared across all alternate
+   Ancestral allele. VCF INFO reserved key AA, Number=1, shared across all alternate
    alleles in the same VCF record.
    */
   union { null, string } ancestralAllele = null;
 
   /**
-   Allele count, VCF INFO reserved key AC, Number=A, split for multi-allelic sites into
+   Allele count. VCF INFO reserved key AC, Number=A, split for multi-allelic sites into
    a single integer value.
    */
   union { null, int } alleleCount = null;
 
   /**
-   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
+   Total alternate read depth. VCF INFO reserved key AD, Number=R, split for multi-allelic
    sites into single integer values for the reference allele (referenceReadDepth) and
-   the alternate allele (readDepth, this field).
+   the alternate allele (alternateReadDepth, this field).
    */
-  union { null, int } readDepth = null;
+  union { null, int } alternateReadDepth = null;
 
   /**
-   Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
+   Forward strand alternate read depth. VCF INFO reserved key ADF, Number=R, split for
    multi-allelic sites into single integer values for the reference allele
-   (referenceForwardReadDepth) and the alternate allele (forwardReadDepth, this field).
+   (referenceForwardReadDepth) and the alternate allele (alternateForwardReadDepth, this field).
    */
-  union { null, int } forwardReadDepth = null;
+  union { null, int } alternateForwardReadDepth = null;
 
   /**
-   Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
+   Reverse strand alternate read depth. VCF INFO reserved key ADR, Number=R, split for
    multi-allelic sites into single integer values for the reference allele
-   (referenceReverseReadDepth) and the alternate allele (reverseReadDepth, this field).
+   (referenceReverseReadDepth) and the alternate allele (alternateReverseReadDepth, this field).
    */
-  union { null, int } reverseReadDepth = null;
+  union { null, int } alternateReverseReadDepth = null;
 
   /**
-   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
+   Total reference read depth. VCF INFO reserved key AD, Number=R, split for multi-allelic
    sites into single integer values for the reference allele (referenceReadDepth, this field)
-   and the alternate allele (readDepth).
+   and the alternate allele (alternateReadDepth).
    */
   union { null, int } referenceReadDepth = null;
 
   /**
-   Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
+   Forward strand reference read depth. VCF INFO reserved key ADF, Number=R, split for
    multi-allelic sites into single integer values for the reference allele
-   (referenceForwardReadDepth, this field) and the alternate allele (forwardReadDepth).
+   (referenceForwardReadDepth, this field) and the alternate allele (alternateForwardReadDepth).
    */
   union { null, int } referenceForwardReadDepth = null;
 
   /**
-   Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
+   Reverse strand reference read depth. VCF INFO reserved key ADR, Number=R, split for
    multi-allelic sites into single integer values for the reference allele
-   (referenceReverseReadDepth, this field) and the alternate allele (reverseReadDepth).
+   (referenceReverseReadDepth, this field) and the alternate allele (alternateReverseReadDepth).
    */
   union { null, int } referenceReverseReadDepth = null;
 
   /**
-   Minor allele frequency, VCF INFO reserved key AF, Number=A, split for multi-allelic
+   Minor allele frequency. VCF INFO reserved key AF, Number=A, split for multi-allelic
    sites into a single float value. Use this when frequencies are estimated from primary
    data, not calculated from called genotypes.
    */
@@ -657,41 +657,41 @@ record VariantAnnotation {
 
   /**
    CIGAR string describing how to align an alternate allele to the reference
-   allele, VCF INFO reserved key CIGAR, Number=A, split for multi-allelic sites into
+   allele. VCF INFO reserved key CIGAR, Number=A, split for multi-allelic sites into
    a single string value.
    */
   union { null, string } cigar = null;
 
   /**
-   Membership in dbSNP, VCF INFO reserved key DB, Number=0. Until Number=A and
+   Membership in dbSNP. VCF INFO reserved key DB, Number=0. Until Number=A and
    Number=R flags are supported by the VCF specification, this value is shared
    across all alternate alleles in the same VCF record.
    */
   union { null, boolean } dbSnp = null;
 
   /**
-   Membership in HapMap2, VCF INFO reserved key H2, Number=0. Until Number=A and
+   Membership in HapMap2. VCF INFO reserved key H2, Number=0. Until Number=A and
    Number=R flags are supported by the VCF specification, this value is shared
    across all alternate alleles in the same VCF record.
    */
   union { null, boolean } hapMap2 = null;
 
   /**
-   Membership in HapMap3, VCF INFO reserved key H3, Number=0. Until Number=A and
+   Membership in HapMap3. VCF INFO reserved key H3, Number=0. Until Number=A and
    Number=R flags are supported by the VCF specification, this value is shared
    across all alternate alleles in the same VCF record.
    */
   union { null, boolean } hapMap3 = null;
 
   /**
-   Validated by follow up experiment, VCF INFO reserved key VALIDATED, Number=0.
+   Validated by follow up experiment. VCF INFO reserved key VALIDATED, Number=0.
    Until Number=A and Number=R flags are supported by the VCF specification, this
    value is shared across all alternate alleles in the same VCF record.
    */
   union { null, boolean } validated = null;
 
   /**
-   Membership in 1000 Genomes, VCF INFO reserved key 1000G, Number=0. Until
+   Membership in 1000 Genomes. VCF INFO reserved key 1000G, Number=0. Until
    Number=A and Number=R flags are supported by the VCF specification, this
    value is shared across all alternate alleles in the same VCF record.
    */
@@ -832,39 +832,189 @@ enum Allele {
 record GenotypeAnnotation {
 
   /**
+   Per-sample total alternate read depth. VCF genotype reserved key AD, Number=R, split for
+   multi-allelic sites into single integer values for the reference allele
+   (referenceReadDepth) and the alternate allele (alternateReadDepth, this field).
+   */
+  union { null, int } alternateReadDepth = null;
+
+  /**
+   Per-sample forward strand alternate read depth. VCF genotype reserved key ADF, Number=R,
+   split for multi-allelic sites into single integer values for the reference allele
+   (referenceForwardReadDepth) and the alternate allele (alternateForwardReadDepth, this field).
+   */
+  union { null, int } alternateForwardReadDepth = null;
+
+  /**
+   Per-sample reverse strand alternate read depth. VCF genotype reserved key ADR, Number=R,
+   split for multi-allelic sites into single integer values for the reference allele
+   (referenceReverseReadDepth) and the alternate allele (alternateReverseReadDepth, this field).
+   */
+  union { null, int } alternateReverseReadDepth = null;
+
+  /**
+   Per-sample total reference read depth. VCF genotype reserved key AD, Number=R, split for
+   multi-allelic sites into single integer values for the reference allele (referenceReadDepth,
+   this field) and the alternate allele (alternateReadDepth).
+   */
+  union { null, int } referenceReadDepth = null;
+
+  /**
+   Per-sample forward strand reference read depth. VCF genotype reserved key ADF, Number=R,
+   split for multi-allelic sites into single integer values for the reference allele
+   (referenceForwardReadDepth, this field) and the alternate allele (alternateForwardReadDepth).
+   */
+  union { null, int } referenceForwardReadDepth = null;
+
+  /**
+   Per-sample reverse strand reference read depth. VCF genotype reserved key ADR, Number=R,
+   split for multi-allelic sites into single integer values for the reference allele
+   (referenceReverseReadDepth, this field) and the alternate allele (alternateReverseReadDepth).
+   */
+  union { null, int } referenceReverseReadDepth = null;
+
+  // DP Number=1 Type=Integer
+  /**
+   Read depth at this position for this sample. VCF genotype field reserved key DP.
+   */
+  union { null, int } readDepth = null;
+
+  // EC Number=A Type=Integer
+  // Comma separated list of expected alternate allele counts for each alternate allele in the same
+  // order as listed in the ALT field. Typically used in association analyses.
+  /**
+   The expected dosage of the alternate allele in this sample. VCF genotype reserved key EC,
+   Number=A, split for multi-allelic sites into a single float value.
+   */
+  union { null, float } expectedAlleleDosage = null; // or expectedAlleleCount? see Variant.alleleCount
+
+  // GL Number=G Type=Float
+  /**
+   Genotype likelihoods comprised of floating point log10-scaled likelihoods for all possible
+   genotypes given [the set of alleles defined in the REF and ALT fields]. VCF genotype field
+   reserved key GL, Number=G.
+   */
+  array<float> likelihoods = [];
+
+  // GLE Number=1 Type=String
+  // Genotype likelihoods of heterogeneous ploidy, used in presence of uncertain copy number.
+  // Reserved genotype field key in VCF v4.2, dropped in VCF v4.3
+
+  // GP Number=G Type=Float
+  /**
+   Genotype posterior probabilities in the range 0.0 to 1.0 using the same ordering as the
+   genotype likelihood field; one use can be to store imputed genotype probabilities. VCF genotype
+   field reserved key GP, Number=G.
+   */
+  array<float> posteriorProbabilities = [];
+
+  // GQ Number=1 Type=Integer
+  /**
    Conditional genotype quality, encoded as a phred quality −10log10 p(genotype call is wrong
    conditioned on the site being variant). VCF genotype field reserved key GQ.
    */
-  union { null, int } genotypeQuality = null;
+  union { null, int } quality = null;
 
+  // HQ Number=2 Type=Integer
   /**
-   Haplotype quality, encoded as two phred qualities. VCF genotype field reserved key HQ.
+   Haplotype quality, encoded as two phred qualities. VCF genotype field reserved key HQ, Number=2.
    */
   array<int> haplotypeQuality = [];
 
-  /**
-   Phred-scaled probability that alleles are ordered incorrectly, against all other members in
-   the same phase set. VCF genotype field reserved key PQ.
-   */
-  union { null, int } phaseSetQuality = null;
-
+  // MQ Number=1 Type=Integer
   /**
    Root Mean Square (RMS) of the mapping quality of reads for this genotype. VCF genotype field
    reserved key MQ.
    */
   union { null, int } rmsMappingQuality = null;
 
+  // PL Number=G Type=Integer
+  /**
+   Phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined precisely
+   as the genotype likelihoods field. VCF genotype field reserved key PL, Number=G.
+   */
+  array<int> phredScaledLikelihoods = [];
+
+  // PQ Number=1 Type=Integer
+  /**
+   Phred-scaled probability that alleles are ordered incorrectly, against all other members in
+   the same phase set. VCF genotype field reserved key PQ.
+   */
+  union { null, int } phaseSetQuality = null;
+
+
+  // SB is not a reserved key in VCF v4.2 or v4.3
   /**
    Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.
    If set, the array should contain the number of reads that support the reference allele on the
    forward strand, the reference allele on the reverse strand, the alternate allele on the forward
    strand, and the alternate allele on the reverse strand, in that order. VCF genotype field key SB.
    */
-  array<int> strandBias = [];
+  //array<int> strandBias = [];  Genotype.strandBiasComponents previously
+
+
+  //
+  // Not present in VCF specification yet present in Genotype
+
+  // The minimum number of reads seen at this site across samples when joint calling variants.
+  // Analogous to VCF's MIN_DP.
+  //union { null, int } minReadDepth = null;
+
+  // Log scaled likelihoods that we have n non-reference alleles at this site. The number of
+  // elements in this array should be equal to the ploidy at this site, plus 1.
+  //array<float> nonReferenceLikelihoods = [];
+
+  // We split multi-allelic VCF lines into multiple single-alternate records. This bit is set
+  // if that happened for this record.
+  //union { boolean, null } splitFromMultiAllelic = false;
+
+
+  //
+  // Not present in VCF specification yet present in VariantCallingAnnotations
+
+  // True if the reads covering this site were randomly downsampled to reduce coverage.
+  //union { null, boolean } downsampled = null;
+
+  // The Wilcoxon rank-sum test statistic of the base quality scores. The base quality
+  // scores are separated by whether or not the base supports the reference or the
+  // alternate allele.
+  //union { null, float } baseQRankSum = null;
+
+  // The Fisher's exact test score for the strand bias of the reference and alternate
+  // alleles.
+  //union { null, float } fisherStrandBiasPValue = null;
+
+  // The number of reads at this site with mapping quality equal to 0.
+  //union { null, int } mapq0Reads = null;
+
+  // The Wilcoxon rank-sum test statistic of the mapping quality scores.
+  //union { null, float } mqRankSum = null;
+
+  // The Wilcoxon rank-sum test statistic of the position of the base in the read at this site.
+  //union { null, float } readPositionRankSum = null;
+
+  // The log scale prior probabilities of the various genotype states at this site.
+  //array<float> genotypePriors = [];
+
+  // The log scaled posterior probabilities of the various genotype states at this site,
+  // in this sample.
+  //array<float> genotypePosteriors = [];  Does this map to GP in the VariantContextConverter?
+
+  // The log-odds ratio of being a true vs. false variant under a trained statistical model.
+  //union { null, float } vqslod = null;
+
+  // If known, the feature that contributed the most to this variant being classified as
+  // a false variant.
+  //union { null, string } culprit = null;
 
   /**
    Additional genotype attributes that do not fit into the standard fields above.
-   The values are stored as strings, even for flag, integer, and float types.
+   The values are stored as strings, even for flag, integer, and float types. VCF
+   genotype key values with Number=., Number=0, Number=1, and Number=[n] are shared across
+   all alternate alleles in the same VCF record. VCF genotype key values with Number=A are
+   split for multi-allelic sites into a single value. VCF genotype key values with Number=R
+   are split into an array of two values, [reference allele, alternate allele], separated
+   by commas, e.g. "0,1".
    */
   map<string> attributes = {};
 }
@@ -875,7 +1025,7 @@ record GenotypeAnnotation {
 record Genotype {
 
   /**
-   The variant for this genotype.
+   The variant for this genotype. May be left unset or set to null for performance reasons.
    */
   union { null, Variant } variant = null;
 
@@ -905,6 +1055,7 @@ record Genotype {
    */
   union { null, string } sampleId = null;
 
+  // GT Number=1 Type=String
   /**
    One or more allele values encoding this genotype. If this genotype is phased, the order of
    the allele values is significant. VCF genotype field reserved key GT mapped to Allele enum
@@ -918,13 +1069,15 @@ record Genotype {
    */
   union { boolean, null } phased = false;
 
+  // PS Number=1 Type=(non-negative 32-bit Integer)
   /**
-   Phase set identifier, if any. Phased genotypes on the same contig with the same phaseSetId
-   are in the same phased set. All phased genotypes that do not have a phaseSetId are assumed to
+   Phase set, if any. Phased genotypes on the same contig with the same phaseSet
+   are in the same phased set. All phased genotypes that do not have a phaseSet are assumed to
    belong to the same phased set. VCF genotype field reserved key PS.
    */
-  union { null, int } phaseSetId = null;
+  union { null, int } phaseSet = null;
 
+  // FT Number=1 Type=String
   /**
    True if filters were applied for this genotype. VCF genotype field reserved key FT any
    value other than the missing value.

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -706,6 +706,12 @@ record VariantAnnotation {
   union { boolean, null } somatic = false;
 
   /**
+   True if this variant call represents a site or gVCF block where no alternate
+   allele was called. This includes both gVCF modes (ERC and BP_RESOLUTION).
+   */
+  union { boolean, null } reference = false;
+
+  /**
    Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
    one per transcript (or other feature). VCF INFO key ANN, split for multi-allelic
    sites. See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
@@ -792,6 +798,20 @@ record Variant {
    all alleles in the same VCF record.
    */
   array<string> filtersFailed = [];
+
+  /**
+   True if this variant is symbolic. If a variant is symbolic, symbolicEnd is populated
+   from the VCF INFO reserved key END. Symbolic alleles encompass structural variants, as
+   well as the "any alt" allele from the gVCF reference model.
+   */
+  union { null, boolean } symbolic = false;
+
+  /**
+   The zero-based, exclusive end position of this symbolic variant on the reference contig.
+   VCF INFO reserved key END, Number=1, shared across all alternate alleles in the same
+   VCF record. Only populated if symbolic is true.
+   */
+  union { null, long } symbolicEnd = null;
 
   /**
    Annotation for this variant, if any.
@@ -901,6 +921,20 @@ record GenotypeAnnotation {
    conditioned on the site being variant). VCF genotype field reserved key GQ.
    */
   union { null, int } quality = null;
+
+  /**
+   For a gVCF block, the minimum phred-scaled probability of the reference genotype call for
+   all bases merged into this block. minGQ in the gVCF block header line, e.g. 0 in
+   ##GVCFBlock=minGQ=0(inclusive),maxGQ=5(exclusive).
+   */
+  union { null, int } minimumQuality = null;
+
+  /**
+   For a gVCF block, the maximum phred-scaled probability of the reference genotype call for
+   all bases merged into this block. maxGQ in the gVCF block header line, e.g. 5 in
+   ##GVCFBlock=minGQ=0(inclusive),maxGQ=5(exclusive).
+   */
+  union { null, int } maximumQuality = null;
 
   // MQ Number=1 Type=Integer
   /**

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -901,11 +901,11 @@ record GenotypeAnnotation {
 
   // GL Number=G Type=Float
   /**
-   Genotype likelihoods comprised of floating point log10-scaled likelihoods for all possible
+   Genotype likelihoods comprised of double floating point log10-scaled likelihoods for all possible
    genotypes given [the set of alleles defined in the REF and ALT fields]. VCF genotype field
    reserved key GL, Number=G.
    */
-  array<float> likelihoods = [];
+  array<double> likelihoods = [];
 
   // GP Number=G Type=Float
   /**
@@ -963,7 +963,7 @@ record GenotypeAnnotation {
    Log scaled likelihoods that we have n non-reference alleles at this site. The number of
    elements in this array should be equal to the ploidy at this site, plus 1.
    */
-  array<float> nonReferenceLikelihoods = [];
+  array<double> nonReferenceLikelihoods = [];
 
 
   //

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -893,32 +893,39 @@ record GenotypeAnnotation {
    */
   union { null, int } referenceReverseReadDepth = null;
 
-  // DP Number=1 Type=Integer
   /**
-   Read depth at this position for this sample. VCF genotype field reserved key DP.
+   Read depth at this position for this sample. VCF genotype field reserved key DP, Number=1.
    */
   union { null, int } readDepth = null;
 
-  // GL Number=G Type=Float
   /**
-   Genotype likelihoods comprised of double floating point log10-scaled likelihoods for all possible
-   genotypes given [the set of alleles defined in the REF and ALT fields]. VCF genotype field
-   reserved key GL, Number=G.
+   Log scaled genotype likelihoods. VCF genotype field reserved key GL, Number=G, converted
+   from log10 scale to natural log scale, or VCF genotype field reserved key PL, Number=G,
+   converted from phred scale to natural log scale.
    */
   array<double> likelihoods = [];
 
-  // GP Number=G Type=Float
   /**
-   Genotype posterior probabilities in the range 0.0 to 1.0 using the same ordering as the
-   genotype likelihood field; one use can be to store imputed genotype probabilities. VCF genotype
-   field reserved key GP, Number=G.
+   Log scaled likelihoods that we have n non-reference alleles at this site. The number of
+   elements in this array should be equal to the ploidy at this site, plus 1.  VCF genotype
+   field key nonReferenceLikelihoods, Number=..
    */
-  array<float> posteriorProbabilities = [];
+  array<double> nonReferenceLikelihoods = [];
 
-  // GQ Number=1 Type=Integer
+  /**
+   Log scaled prior probabilities. VCF genotype field key priors, Number=G.
+   */
+  array<float> priors = [];
+
+  /**
+   Log scaled posterior probabilities. VCF genotype field reserved key GP, Number=G, converted
+   from log10 scale to natural log scale.
+   */
+  array<float> posteriors = [];
+
   /**
    Conditional genotype quality, encoded as a phred quality −10log10 p(genotype call is wrong
-   conditioned on the site being variant). VCF genotype field reserved key GQ.
+   conditioned on the site being variant). VCF genotype field reserved key GQ, Number=1.
    */
   union { null, int } quality = null;
 
@@ -936,76 +943,34 @@ record GenotypeAnnotation {
    */
   union { null, int } maximumQuality = null;
 
-  // MQ Number=1 Type=Integer
   /**
    Root Mean Square (RMS) of the mapping quality of reads for this genotype. VCF genotype field
-   reserved key MQ.
+   reserved key MQ, Number=1.
    */
   union { null, int } rmsMappingQuality = null;
 
-  // PQ Number=1 Type=Integer
   /**
    Phred-scaled probability that alleles are ordered incorrectly, against all other members in
-   the same phase set. VCF genotype field reserved key PQ.
+   the same phase set. VCF genotype field reserved key PQ, Number=1.
    */
   union { null, int } phaseSetQuality = null;
 
-  //
-  // Not present in VCF specification yet present in Genotype
-
   /**
    Minimum number of reads seen at this site across samples when joint calling variants.
-   VCF genotype field key MIN_DP.
+   VCF genotype field key MIN_DP, Number=1.
    */
   union { null, int } minimumReadDepth = null;
-
-  /**
-   Log scaled likelihoods that we have n non-reference alleles at this site. The number of
-   elements in this array should be equal to the ploidy at this site, plus 1.
-   */
-  array<double> nonReferenceLikelihoods = [];
-
-
-  //
-  // Not present in VCF specification yet present in VariantCallingAnnotations
 
   /**
    True if the reads covering this site were randomly downsampled to reduce coverage.
    */
   union { null, boolean } downsampled = null;
 
-  // The Wilcoxon rank-sum test statistic of the base quality scores. The base quality
-  // scores are separated by whether or not the base supports the reference or the
-  // alternate allele.
-  //union { null, float } baseQRankSum = null;
-
   /**
    Fisher's exact test score for the strand bias of the reference and alternate alleles.
+   VCF genotype field key fisherStrandBiasPValue, Number=1 Type=Float.
    */
   union { null, float } fisherStrandBiasPValue = null;
-
-  // The number of reads at this site with mapping quality equal to 0.
-  //union { null, int } mapq0Reads = null;
-
-  // The Wilcoxon rank-sum test statistic of the mapping quality scores.
-  //union { null, float } mqRankSum = null;
-
-  // The Wilcoxon rank-sum test statistic of the position of the base in the read at this site.
-  //union { null, float } readPositionRankSum = null;
-
-  // The log scale prior probabilities of the various genotype states at this site.
-  //array<float> genotypePriors = [];
-
-  // The log scaled posterior probabilities of the various genotype states at this site,
-  // in this sample.
-  //array<float> genotypePosteriors = [];  Does this map to GP in the VariantContextConverter?
-
-  // The log-odds ratio of being a true vs. false variant under a trained statistical model.
-  //union { null, float } vqslod = null;
-
-  // If known, the feature that contributed the most to this variant being classified as
-  // a false variant.
-  //union { null, string } culprit = null;
 
   /**
    Additional genotype attributes that do not fit into the standard fields above.
@@ -1055,7 +1020,6 @@ record Genotype {
    */
   union { null, string } sampleId = null;
 
-  // GT Number=1 Type=String
   /**
    One or more allele values encoding this genotype. If this genotype is phased, the order of
    the allele values is significant. VCF genotype field reserved key GT mapped to Allele enum
@@ -1069,15 +1033,13 @@ record Genotype {
    */
   union { boolean, null } phased = false;
 
-  // PS Number=1 Type=(non-negative 32-bit Integer)
   /**
    Phase set, if any. Phased genotypes on the same contig with the same phaseSet
    are in the same phased set. All phased genotypes that do not have a phaseSet are assumed to
-   belong to the same phased set. VCF genotype field reserved key PS.
+   belong to the same phased set. VCF genotype field reserved key PS, Number=1.
    */
   union { null, int } phaseSet = null;
 
-  // FT Number=1 Type=String
   /**
    True if filters were applied for this genotype. VCF genotype field reserved key FT any
    value other than the missing value.


### PR DESCRIPTION
Starting point for discussion around `Genotype` and `GenotypeAnnotation`.  This is a tear-down-and-rebuild, where `VariantCallingAnnotations` has been removed and the bare minimum put back in.
