### PR TITLE
Add forward reference between Variant and VariantAnnotation

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -421,12 +421,9 @@ record Variant {
   array<string> filtersFailed = [];
 
   /**
-   True if this variant call is somatic; in this case, the referenceAllele will
-   have been observed in another sample. VCF INFO reserved key "SOMATIC", Number=0.
-   Until Number=A and Number=R flags are supported by the VCF specification, this value
-   is shared across all alleles in the same VCF record.
+   Annotation for this variant, if any.
    */
-  union { boolean, null } somatic = false;
+  union { null, VariantAnnotation } annotation = null;
 }
 
 /**
@@ -917,11 +914,6 @@ record TranscriptEffect {
 record VariantAnnotation {
 
   /**
-   Variant for this annotation.
-   */
-  union { null, Variant } variant = null;
-
-  /**
    Ancestral allele, VCF INFO reserved key AA, Number=1, shared across all alternate
    alleles in the same VCF record.
    */
@@ -999,9 +991,17 @@ record VariantAnnotation {
   union { null, boolean } thousandGenomes = null;
 
   /**
+   True if this variant call is somatic; in this case, the reference allele will
+   have been observed in another sample. VCF INFO reserved key "SOMATIC", Number=0.
+   Until Number=A and Number=R flags are supported by the VCF specification, this value
+   is shared across all alleles in the same VCF record.
+   */
+  union { boolean, null } somatic = false;
+
+  /**
    Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
    one per transcript (or other feature). VCF INFO header key ANN, split for multi-allelic
-   sites.  See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
+   sites. See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
    */
   array<TranscriptEffect> transcriptEffects = [];
 

--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -364,6 +364,299 @@ record NucleotideContigFragment {
 }
 
 /**
+ Errors, warnings, or informative messages regarding variant annotation accuracy.
+ */
+enum VariantAnnotationMessage {
+
+  /**
+   Chromosome does not exist in reference genome database. Typically indicates
+   a mismatch between the chromosome names in the input file and the chromosome
+   names used in the reference genome. Message code E1.
+   */
+  ERROR_CHROMOSOME_NOT_FOUND,
+
+  /**
+   The variant's genomic coordinate is greater than chromosome's length.
+   Message code E2.
+   */
+  ERROR_OUT_OF_CHROMOSOME_RANGE,
+
+  /**
+   The 'REF' field in the input VCF file does not match the reference genome.
+   This warning may indicate a conflict between input data and data from
+   reference genome (for instance is the input VCF was aligned to a different
+   reference genome). Message code W1.
+   */
+  WARNING_REF_DOES_NOT_MATCH_GENOME,
+
+  /**
+   Reference sequence is not available, thus no inference could be performed.
+   Message code W2.
+   */
+  WARNING_SEQUENCE_NOT_AVAILABLE,
+
+  /**
+   A protein coding transcript having a non­multiple of 3 length. It indicates
+   that the reference genome has missing information about this particular
+   transcript. Message code W3.
+   */
+  WARNING_TRANSCRIPT_INCOMPLETE,
+
+  /**
+   A protein coding transcript has two or more STOP codons in the middle of
+   the coding sequence (CDS). This should not happen and it usually means the
+   reference genome may have an error in this transcript. Message code W4.
+   */
+  WARNING_TRANSCRIPT_MULTIPLE_STOP_CODONS,
+
+  /**
+   A protein coding transcript does not have a proper START codon. It is
+   rare that a real transcript does not have a START codon, so this probably
+   indicates an error or missing information in the reference genome.
+   Message code W5.
+   */
+  WARNING_TRANSCRIPT_NO_START_CODON,
+
+  /**
+   Variant has been realigned to the most 3­prime position within the
+   transcript. This is usually done to to comply with HGVS specification
+   to always report the most 3­prime annotation. Message code I1.
+   */
+  INFO_REALIGN_3_PRIME,
+
+  /**
+   This effect is a result of combining more than one variants (e.g. two
+   consecutive SNPs that conform an MNP, or two consecutive frame_shift
+   variants that compensate frame). Message code I2.
+   */
+  INFO_COMPOUND_ANNOTATION,
+
+  /**
+   An alternative reference sequence was used to calculate this annotation
+   (e.g. cancer sample comparing somatic vs. germline). Message code I3.
+   */
+  INFO_NON_REFERENCE_ANNOTATION
+}
+
+/**
+ Annotation of a variant in the context of a feature, typically a transcript.
+ */
+record TranscriptEffect {
+
+  /**
+   Alternate allele for this variant annotation.
+   */
+  union { null, string } alternateAllele = null;
+
+  /**
+   One or more annotations (also referred to as effects or consequences) of the
+   variant in the context of the feature identified by featureId. Must be
+   Sequence Ontology (SO, see http://www.sequenceontology.org) term names, e.g.
+   stop_gained, missense_variant, synonymous_variant, upstream_gene_variant.
+   */
+  array<string> effects = [];
+
+  /**
+   Common gene name (HGNC), e.g. BRCA2. May be closest gene if annotation
+   is intergenic.
+   */
+  union { null, string } geneName = null;
+
+  /**
+   Gene identifier, e.g. Ensembl Gene identifier, ENSG00000139618. May be
+   closest gene if annotation is intergenic.
+   */
+  union { null, string } geneId = null;
+
+  /**
+   Feature type, may use Sequence Ontology term names. Typically transcript.
+   */
+  union { null, string } featureType = null;
+
+  /**
+   Feature identifier, e.g. Ensembl Transcript identifier and version, ENST00000380152.7.
+   */
+  union { null, string } featureId = null;
+
+  /**
+   Feature biotype, e.g. Protein coding or Non coding. See http://vega.sanger.ac.uk/info/about/gene_and_transcript_types.html.
+   */
+  union { null, string } biotype = null;
+
+  /**
+   Intron or exon rank.
+   */
+  union { null, int } rank = null;
+
+  /**
+   Total number of introns or exons.
+   */
+  union { null, int } total = null;
+
+  /**
+   HGVS.g description of the variant. See http://www.hgvs.org/mutnomen/recs-DNA.html.
+   */
+  union { null, string } genomicHgvs = null;
+
+  /**
+   HGVS.c description of the variant. See http://www.hgvs.org/mutnomen/recs-DNA.html.
+   */
+  union { null, string } transcriptHgvs = null;
+
+  /**
+   HGVS.p description of the variant, if coding. See http://www.hgvs.org/mutnomen/recs-prot.html.
+   */
+  union { null, string } proteinHgvs = null;
+
+  /**
+   cDNA sequence position (one based).
+   */
+  union { null, int } cdnaPosition = null;
+
+  /**
+   cDNA sequence length in base pairs (one based).
+   */
+  union { null, int } cdnaLength = null;
+
+  /**
+   Coding sequence position (one based, includes START and STOP codons).
+   */
+  union { null, int } cdsPosition = null;
+
+  /**
+   Coding sequence length in base pairs (one based, includes START and STOP codons).
+   */
+  union { null, int } cdsLength = null;
+
+  /**
+   Protein sequence position (one based, includes START but not STOP).
+   */
+  union { null, int } proteinPosition = null;
+
+  /**
+   Protein sequence length in amino acids (one based, includes START but not STOP).
+   */
+  union { null, int } proteinLength = null;
+
+  /**
+   Distance in base pairs to the feature.
+   */
+  union { null, int } distance = null;
+
+  /**
+   Zero or more errors, warnings, or informative messages regarding variant annotation accuracy.
+   */
+  array<VariantAnnotationMessage> messages = [];
+}
+
+/**
+ Variant annotation.
+ */
+record VariantAnnotation {
+
+  /**
+   Ancestral allele, VCF INFO reserved key AA, Number=1, shared across all alternate
+   alleles in the same VCF record.
+   */
+  union { null, string } ancestralAllele = null;
+
+  /**
+   Allele count, VCF INFO reserved key AC, Number=A, split for multi-allelic sites.
+   */
+  union { null, int } alleleCount = null;
+
+  /**
+   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
+   sites.
+   */
+  union { null, int } readDepth = null;
+
+  /**
+   Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
+   multi-allelic sites.
+   */
+  union { null, int } forwardReadDepth = null;
+
+  /**
+   Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
+   multi-allelic sites.
+   */
+  union { null, int } reverseReadDepth = null;
+
+  /**
+   Minor allele frequency, VCF INFO reserved key AF, Number=A, split for multi-allelic
+   sites. Use this when frequencies are estimated from primary data, not calculated
+   from called genotypes.
+   */
+  union { null, float } alleleFrequency = null;
+
+  /**
+   CIGAR string describing how to align an alternate allele to the reference
+   allele, VCF INFO reserved key CIGAR, Number=A, split for multi-allelic sites.
+   */
+  union { null, string } cigar = null;
+
+  /**
+   Membership in dbSNP, VCF INFO reserved key DB, Number=0. Until Number=A and
+   Number=R flags are supported by the VCF specification, this value is shared
+   across all alternate alleles in the same VCF record.
+   */
+  union { null, boolean } dbSnp = null;
+
+  /**
+   Membership in HapMap2, VCF INFO reserved key H2, Number=0. Until Number=A and
+   Number=R flags are supported by the VCF specification, this value is shared
+   across all alternate alleles in the same VCF record.
+   */
+  union { null, boolean } hapMap2 = null;
+
+  /**
+   Membership in HapMap3, VCF INFO reserved key H3, Number=0. Until Number=A and
+   Number=R flags are supported by the VCF specification, this value is shared
+   across all alternate alleles in the same VCF record.
+   */
+  union { null, boolean } hapMap3 = null;
+
+  /**
+   Validated by follow up experiment, VCF INFO reserved key VALIDATED, Number=0.
+   Until Number=A and Number=R flags are supported by the VCF specification, this
+   value is shared across all alternate alleles in the same VCF record.
+   */
+  union { null, boolean } validated = null;
+
+  /**
+   Membership in 1000 Genomes, VCF INFO reserved key 1000G, Number=0. Until
+   Number=A and Number=R flags are supported by the VCF specification, this
+   value is shared across all alternate alleles in the same VCF record.
+   */
+  union { null, boolean } thousandGenomes = null;
+
+  /**
+   True if this variant call is somatic; in this case, the reference allele will
+   have been observed in another sample. VCF INFO reserved key "SOMATIC", Number=0.
+   Until Number=A and Number=R flags are supported by the VCF specification, this value
+   is shared across all alleles in the same VCF record.
+   */
+  union { boolean, null } somatic = false;
+
+  /**
+   Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
+   one per transcript (or other feature). VCF INFO header key ANN, split for multi-allelic
+   sites. See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
+   */
+  array<TranscriptEffect> transcriptEffects = [];
+
+  /**
+   Additional variant attributes that do not fit into the standard fields above.
+   The values are stored as strings, even for flag, integer, and float types. VCF
+   INFO key values with Number=., Number=0, Number=1, and Number=[n] are shared across
+   all alternate alleles in the same VCF record. VCF INFO key values with Number=A and
+   Number=R are split for multi-allelic sites.
+   */
+  map<string> attributes = {};
+}
+
+/**
  Variant.
  */
 record Variant {
@@ -720,299 +1013,6 @@ record Genotype {
    is phased. Should only be populated if phased == true; else should be null.
    */
   union { null, int } phaseQuality = null;
-}
-
-/**
- Errors, warnings, or informative messages regarding variant annotation accuracy.
- */
-enum VariantAnnotationMessage {
-
-  /**
-   Chromosome does not exist in reference genome database. Typically indicates
-   a mismatch between the chromosome names in the input file and the chromosome
-   names used in the reference genome. Message code E1.
-   */
-  ERROR_CHROMOSOME_NOT_FOUND,
-
-  /**
-   The variant's genomic coordinate is greater than chromosome's length.
-   Message code E2.
-   */
-  ERROR_OUT_OF_CHROMOSOME_RANGE,
-
-  /**
-   The 'REF' field in the input VCF file does not match the reference genome.
-   This warning may indicate a conflict between input data and data from
-   reference genome (for instance is the input VCF was aligned to a different
-   reference genome). Message code W1.
-   */
-  WARNING_REF_DOES_NOT_MATCH_GENOME,
-
-  /**
-   Reference sequence is not available, thus no inference could be performed.
-   Message code W2.
-   */
-  WARNING_SEQUENCE_NOT_AVAILABLE,
-
-  /**
-   A protein coding transcript having a non­multiple of 3 length. It indicates
-   that the reference genome has missing information about this particular
-   transcript. Message code W3.
-   */
-  WARNING_TRANSCRIPT_INCOMPLETE,
-
-  /**
-   A protein coding transcript has two or more STOP codons in the middle of
-   the coding sequence (CDS). This should not happen and it usually means the
-   reference genome may have an error in this transcript. Message code W4.
-   */
-  WARNING_TRANSCRIPT_MULTIPLE_STOP_CODONS,
-
-  /**
-   A protein coding transcript does not have a proper START codon. It is
-   rare that a real transcript does not have a START codon, so this probably
-   indicates an error or missing information in the reference genome.
-   Message code W5.
-   */
-  WARNING_TRANSCRIPT_NO_START_CODON,
-
-  /**
-   Variant has been realigned to the most 3­prime position within the
-   transcript. This is usually done to to comply with HGVS specification
-   to always report the most 3­prime annotation. Message code I1.
-   */
-  INFO_REALIGN_3_PRIME,
-
-  /**
-   This effect is a result of combining more than one variants (e.g. two
-   consecutive SNPs that conform an MNP, or two consecutive frame_shift
-   variants that compensate frame). Message code I2.
-   */
-  INFO_COMPOUND_ANNOTATION,
-
-  /**
-   An alternative reference sequence was used to calculate this annotation
-   (e.g. cancer sample comparing somatic vs. germline). Message code I3.
-   */
-  INFO_NON_REFERENCE_ANNOTATION
-}
-
-/**
- Annotation of a variant in the context of a feature, typically a transcript.
- */
-record TranscriptEffect {
-
-  /**
-   Alternate allele for this variant annotation.
-   */
-  union { null, string } alternateAllele = null;
-
-  /**
-   One or more annotations (also referred to as effects or consequences) of the
-   variant in the context of the feature identified by featureId. Must be
-   Sequence Ontology (SO, see http://www.sequenceontology.org) term names, e.g.
-   stop_gained, missense_variant, synonymous_variant, upstream_gene_variant.
-   */
-  array<string> effects = [];
-
-  /**
-   Common gene name (HGNC), e.g. BRCA2. May be closest gene if annotation
-   is intergenic.
-   */
-  union { null, string } geneName = null;
-
-  /**
-   Gene identifier, e.g. Ensembl Gene identifier, ENSG00000139618. May be
-   closest gene if annotation is intergenic.
-   */
-  union { null, string } geneId = null;
-
-  /**
-   Feature type, may use Sequence Ontology term names. Typically transcript.
-   */
-  union { null, string } featureType = null;
-
-  /**
-   Feature identifier, e.g. Ensembl Transcript identifier and version, ENST00000380152.7.
-   */
-  union { null, string } featureId = null;
-
-  /**
-   Feature biotype, e.g. Protein coding or Non coding. See http://vega.sanger.ac.uk/info/about/gene_and_transcript_types.html.
-   */
-  union { null, string } biotype = null;
-
-  /**
-   Intron or exon rank.
-   */
-  union { null, int } rank = null;
-
-  /**
-   Total number of introns or exons.
-   */
-  union { null, int } total = null;
-
-  /**
-   HGVS.g description of the variant. See http://www.hgvs.org/mutnomen/recs-DNA.html.
-   */
-  union { null, string } genomicHgvs = null;
-
-  /**
-   HGVS.c description of the variant. See http://www.hgvs.org/mutnomen/recs-DNA.html.
-   */
-  union { null, string } transcriptHgvs = null;
-
-  /**
-   HGVS.p description of the variant, if coding. See http://www.hgvs.org/mutnomen/recs-prot.html.
-   */
-  union { null, string } proteinHgvs = null;
-
-  /**
-   cDNA sequence position (one based).
-   */
-  union { null, int } cdnaPosition = null;
-
-  /**
-   cDNA sequence length in base pairs (one based).
-   */
-  union { null, int } cdnaLength = null;
-
-  /**
-   Coding sequence position (one based, includes START and STOP codons).
-   */
-  union { null, int } cdsPosition = null;
-
-  /**
-   Coding sequence length in base pairs (one based, includes START and STOP codons).
-   */
-  union { null, int } cdsLength = null;
-
-  /**
-   Protein sequence position (one based, includes START but not STOP).
-   */
-  union { null, int } proteinPosition = null;
-
-  /**
-   Protein sequence length in amino acids (one based, includes START but not STOP).
-   */
-  union { null, int } proteinLength = null;
-
-  /**
-   Distance in base pairs to the feature.
-   */
-  union { null, int } distance = null;
-
-  /**
-   Zero or more errors, warnings, or informative messages regarding variant annotation accuracy.
-   */
-  array<VariantAnnotationMessage> messages = [];
-}
-
-/**
- Variant annotation.
- */
-record VariantAnnotation {
-
-  /**
-   Ancestral allele, VCF INFO reserved key AA, Number=1, shared across all alternate
-   alleles in the same VCF record.
-   */
-  union { null, string } ancestralAllele = null;
-
-  /**
-   Allele count, VCF INFO reserved key AC, Number=A, split for multi-allelic sites.
-   */
-  union { null, int } alleleCount = null;
-
-  /**
-   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
-   sites.
-   */
-  union { null, int } readDepth = null;
-
-  /**
-   Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
-   multi-allelic sites.
-   */
-  union { null, int } forwardReadDepth = null;
-
-  /**
-   Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
-   multi-allelic sites.
-   */
-  union { null, int } reverseReadDepth = null;
-
-  /**
-   Minor allele frequency, VCF INFO reserved key AF, Number=A, split for multi-allelic
-   sites. Use this when frequencies are estimated from primary data, not calculated
-   from called genotypes.
-   */
-  union { null, float } alleleFrequency = null;
-
-  /**
-   CIGAR string describing how to align an alternate allele to the reference
-   allele, VCF INFO reserved key CIGAR, Number=A, split for multi-allelic sites.
-   */
-  union { null, string } cigar = null;
-
-  /**
-   Membership in dbSNP, VCF INFO reserved key DB, Number=0. Until Number=A and
-   Number=R flags are supported by the VCF specification, this value is shared
-   across all alternate alleles in the same VCF record.
-   */
-  union { null, boolean } dbSnp = null;
-
-  /**
-   Membership in HapMap2, VCF INFO reserved key H2, Number=0. Until Number=A and
-   Number=R flags are supported by the VCF specification, this value is shared
-   across all alternate alleles in the same VCF record.
-   */
-  union { null, boolean } hapMap2 = null;
-
-  /**
-   Membership in HapMap3, VCF INFO reserved key H3, Number=0. Until Number=A and
-   Number=R flags are supported by the VCF specification, this value is shared
-   across all alternate alleles in the same VCF record.
-   */
-  union { null, boolean } hapMap3 = null;
-
-  /**
-   Validated by follow up experiment, VCF INFO reserved key VALIDATED, Number=0.
-   Until Number=A and Number=R flags are supported by the VCF specification, this
-   value is shared across all alternate alleles in the same VCF record.
-   */
-  union { null, boolean } validated = null;
-
-  /**
-   Membership in 1000 Genomes, VCF INFO reserved key 1000G, Number=0. Until
-   Number=A and Number=R flags are supported by the VCF specification, this
-   value is shared across all alternate alleles in the same VCF record.
-   */
-  union { null, boolean } thousandGenomes = null;
-
-  /**
-   True if this variant call is somatic; in this case, the reference allele will
-   have been observed in another sample. VCF INFO reserved key "SOMATIC", Number=0.
-   Until Number=A and Number=R flags are supported by the VCF specification, this value
-   is shared across all alleles in the same VCF record.
-   */
-  union { boolean, null } somatic = false;
-
-  /**
-   Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
-   one per transcript (or other feature). VCF INFO header key ANN, split for multi-allelic
-   sites. See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
-   */
-  array<TranscriptEffect> transcriptEffects = [];
-
-  /**
-   Additional variant attributes that do not fit into the standard fields above.
-   The values are stored as strings, even for flag, integer, and float types. VCF
-   INFO key values with Number=., Number=0, Number=1, and Number=[n] are shared across
-   all alternate alleles in the same VCF record. VCF INFO key values with Number=A and
-   Number=R are split for multi-allelic sites.
-   */
-  map<string> attributes = {};
 }
 
 /**


### PR DESCRIPTION
Fixes #116 

Moved `somatic` field from `Variant` to `VariantAnnotation` so that VCF INFO header parsing isn't split between both record types.

Prepares for flattening `VariantAnnotation` into `Variant` at a later date.

Pushed as separate commits since the minor change required reordering the record declarations.