### PR TITLE
[FORMATS-124] Add field for generic non-reference allele.

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -725,6 +725,12 @@ record Variant {
   union { null, string } alternateAllele = null;
 
   /**
+   True if this variant is the gVCF symbolic "<NON_REF>" allele. This allele models the
+   presence of a generic, unknown non-reference allele.
+   */
+  union { boolean, null } isNonReferenceModel = false;
+
+  /**
    True if filters were applied for this variant. VCF column 7 "FILTER" any value other
    than the missing value.
    */


### PR DESCRIPTION
Resolves #124. Adds a field to cover the case where a variant contains a symbolic non-reference alternate allele.

I'm not sure if I like this approach. Putting it out there to see if other people like it or don't like it.