### PR TITLE
[FORMATS-142] Replace NucleotideContigFragment with Sequence and Slice

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -352,68 +352,6 @@ record Fragment {
 }
 
 /**
- Stores a contig of nucleotides; this may be a reference chromosome, may be an
- assembly, may be a BAC. Very long contigs (>1Mbp) need to be split into fragments.
- It seems that they are too long to load in a single go. For best performance,
- it seems like 10kbp is a good point at which to start splitting contigs into
- fragments.
- */
-record NucleotideContigFragment {
-
-  /**
-   The name of this contig in the assembly (e.g., "1").
-   */
-  union { null, string } contigName = null;
-
-  /**
-   The total length of the contig this fragment is from.
-   */
-  union { null, long } contigLength = null;
-
-  /**
-   A description for this contig. When importing from FASTA, the FASTA header
-   description line should be stored here.
-   */
-  union { null, string } description = null;
-
-  /**
-   The sequence of bases in this fragment.
-   */
-  union { null, string } sequence = null;
-
-  /**
-   In a fragmented contig, the index of this fragment in the set of fragments.
-   Can be null if the contig is not fragmented.
-   */
-  union { null, int } index = null;
-
-  /**
-   The position of the first base of this fragment in the overall contig. E.g.,
-   if all fragments are 10kbp and this is the third fragment in the contig,
-   the start position would be 20000L.
-   */
-  union { null, long } start = null;
-
-  /**
-   The position of the last base of this fragment in the overall contig. E.g.,
-   if all fragments are 10kbp and this is the third fragment in the contig,
-   the end position would be 29999L.
-   */
-  union { null, long } end = null;
-
-  /**
-   The length of this fragment.
-   */
-  union { null, long } length = null;
-
-  /**
-   The total count of fragments that this contig has been broken into. Can be
-   null if the contig is not fragmented.
-   */
-  union { null, int } fragments = null;
-}
-
-/**
  Errors, warnings, or informative messages regarding variant annotation accuracy.
  */
 enum VariantAnnotationMessage {


### PR DESCRIPTION
Fixes #142 

Mapped NucleotideContigFragment fields:
```
contigName --> name
contigLength --> totalLength
description --> description
sequence --> sequence
index --> index
start --> start
end --> end
length --> length
fragments --> slices
```
Unmapped NucleotideContigFragment fields:

None

Unmapped Slice fields:
```
alphabet
strand
attributes
```

This will allow refactoring the org.bdgenomics.adam.rdd.contig package in ADAM to org.bdgenomics.adam.rdd.sequence with not much more than class and field renames.