### PR TITLE
[FORMATS-106] Refactor Genotype and GenotypeAnnotation.

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -676,13 +676,13 @@ record VariantAnnotation {
   union { null, string } ancestralAllele = null;
 
   /**
-   Allele count, VCF INFO reserved key AC, Number=A, split for multi-allelic sites into
+   Allele count, VCF INFO reserved key AC, Number=A, split for multiallelic sites into
    a single integer value.
    */
   union { null, int } alleleCount = null;
 
   /**
-   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
+   Total read depth, VCF INFO reserved key AD, Number=R, split for multiallelic
    sites into single integer values for the reference allele (referenceReadDepth) and
    the alternate allele (readDepth, this field).
    */
@@ -690,20 +690,20 @@ record VariantAnnotation {
 
   /**
    Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
-   multi-allelic sites into single integer values for the reference allele
+   multiallelic sites into single integer values for the reference allele
    (referenceForwardReadDepth) and the alternate allele (forwardReadDepth, this field).
    */
   union { null, int } forwardReadDepth = null;
 
   /**
    Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
-   multi-allelic sites into single integer values for the reference allele
+   multiallelic sites into single integer values for the reference allele
    (referenceReverseReadDepth) and the alternate allele (reverseReadDepth, this field).
    */
   union { null, int } reverseReadDepth = null;
 
   /**
-   Total read depth, VCF INFO reserved key AD, Number=R, split for multi-allelic
+   Total read depth, VCF INFO reserved key AD, Number=R, split for multiallelic
    sites into single integer values for the reference allele (referenceReadDepth, this field)
    and the alternate allele (readDepth).
    */
@@ -711,20 +711,20 @@ record VariantAnnotation {
 
   /**
    Forward strand read depth, VCF INFO reserved key ADF, Number=R, split for
-   multi-allelic sites into single integer values for the reference allele
+   multiallelic sites into single integer values for the reference allele
    (referenceForwardReadDepth, this field) and the alternate allele (forwardReadDepth).
    */
   union { null, int } referenceForwardReadDepth = null;
 
   /**
    Reverse strand read depth, VCF INFO reserved key ADR, Number=R, split for
-   multi-allelic sites into single integer values for the reference allele
+   multiallelic sites into single integer values for the reference allele
    (referenceReverseReadDepth, this field) and the alternate allele (reverseReadDepth).
    */
   union { null, int } referenceReverseReadDepth = null;
 
   /**
-   Minor allele frequency, VCF INFO reserved key AF, Number=A, split for multi-allelic
+   Minor allele frequency, VCF INFO reserved key AF, Number=A, split for multiallelic
    sites into a single float value. Use this when frequencies are estimated from primary
    data, not calculated from called genotypes.
    */
@@ -732,7 +732,7 @@ record VariantAnnotation {
 
   /**
    CIGAR string describing how to align an alternate allele to the reference
-   allele, VCF INFO reserved key CIGAR, Number=A, split for multi-allelic sites into
+   allele, VCF INFO reserved key CIGAR, Number=A, split for multiallelic sites into
    a single string value.
    */
   union { null, string } cigar = null;
@@ -782,7 +782,7 @@ record VariantAnnotation {
 
   /**
    Zero or more transcript effects, predicted by a tool such as SnpEff or Ensembl VEP,
-   one per transcript (or other feature). VCF INFO key ANN, split for multi-allelic
+   one per transcript (or other feature). VCF INFO key ANN, split for multiallelic
    sites. See http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf.
    */
   array<TranscriptEffect> transcriptEffects = [];
@@ -792,7 +792,7 @@ record VariantAnnotation {
    The values are stored as strings, even for flag, integer, and float types. VCF
    INFO key values with Number=., Number=0, Number=1, and Number=[n] are shared across
    all alternate alleles in the same VCF record. VCF INFO key values with Number=A are
-   split for multi-allelic sites into a single value. VCF INFO key values with Number=R
+   split for multiallelic sites into a single value. VCF INFO key values with Number=R
    are split into an array of two values, [reference allele, alternate allele], separated
    by commas, e.g. "0,1".
    */
@@ -829,10 +829,10 @@ record Variant {
   array<string> names = [];
 
   /**
-   We split multi-allelic VCF lines into multiple single-alternate records.
+   We split multiallelic VCF lines into multiple single-alternate records.
    This bit is set if that happened for this record.
    */
-  union { boolean, null } splitFromMultiAllelic = false;
+  union { boolean, null } splitFromMultiallelic = false;
 
   /**
    A string describing the reference allele at this site. VCF column 4 "REF".
@@ -841,13 +841,13 @@ record Variant {
 
   /**
    A string describing the alternate allele at this site. VCF column 5 "ALT" split
-   for multi-allelic sites.
+   for multiallelic sites.
    */
   union { null, string } alternateAllele = null;
 
   /**
    The Phred scaled probability that this allele is variant. VCF column 6 "QUAL".
-   If this record is multi-allelic, this value may be incorrect.
+   If this record is multiallelic, this value may be incorrect.
    */
   union { null, double } quality = null;
 
@@ -875,83 +875,146 @@ record Variant {
 }
 
 /**
- An enumeration that describes the allele that corresponds to a genotype.
+ Allele encodings for genotypes.
  */
-enum GenotypeAllele {
+enum Allele {
 
   /**
-   The genotype is the reference allele.
+   Reference allele.
    */
   REF,
 
   /**
-   The genotype is the alternate allele.
+   Alternate allele.
    */
   ALT,
 
   /**
-   The genotype is an unspecified other alternate allele. This occurs in our schema
-   when we have split a multi-allelic genotype into two genotype records.
+   An unspecified other alternate allele. This may occur when the variant for
+   the genotype partially encoded by this allele is split as a multiallelic site.
    */
   OTHER_ALT,
 
   /**
-   The genotype could not be called.
+   Missing allele.
    */
   NO_CALL
 }
 
 /**
- An enumeration that describes the characteristics of a genotype at a site.
+ Genotype annotation.
  */
-enum GenotypeType {
+record GenotypeAnnotation {
 
   /**
-   All genotypes at this site were called as the reference allele.
+   Per-sample total alternate read depth. VCF genotype reserved key AD, Number=R, split for
+   multiallelic sites into single integer values for the reference allele
+   (referenceReadDepth) and the alternate allele (alternateReadDepth, this field).
    */
-  HOM_REF,
+  union { null, int } alternateReadDepth = null;
 
   /**
-   Genotypes at this site were called as multiple different alleles. This
-   most commonly occurs if a diploid sample's genotype contains one reference
-   and one variant allele, but can also occur if the genotype contains multiple
-   alternate alleles.
+   Per-sample forward strand alternate read depth. VCF genotype reserved key ADF, Number=R,
+   split for multiallelic sites into single integer values for the reference allele
+   (referenceForwardReadDepth) and the alternate allele (alternateForwardReadDepth, this field).
    */
-  HET,
+  union { null, int } alternateForwardReadDepth = null;
 
   /**
-   All genotypes at this site were called as a single alternate allele.
+   Per-sample reverse strand alternate read depth. VCF genotype reserved key ADR, Number=R,
+   split for multiallelic sites into single integer values for the reference allele
+   (referenceReverseReadDepth) and the alternate allele (alternateReverseReadDepth, this field).
    */
-  HOM_ALT,
+  union { null, int } alternateReverseReadDepth = null;
 
   /**
-   The genotype could not be called at this site.
+   Per-sample total reference read depth. VCF genotype reserved key AD, Number=R, split for
+   multiallelic sites into single integer values for the reference allele (referenceReadDepth,
+   this field) and the alternate allele (alternateReadDepth).
    */
-  NO_CALL
-}
-
-/**
- This record represents all stats that, inside a VCF, are stored outside of the
- sample but are computed based on the samples. For instance, MAPQ0 is an aggregate
- stat computed from all samples and stored inside the INFO line.
- */
-record VariantCallingAnnotations {
+  union { null, int } referenceReadDepth = null;
 
   /**
-   True if filters were applied for this genotype call. FORMAT field "FT" any value other
-   than the missing value.
+   Per-sample forward strand reference read depth. VCF genotype reserved key ADF, Number=R,
+   split for multiallelic sites into single integer values for the reference allele
+   (referenceForwardReadDepth, this field) and the alternate allele (alternateForwardReadDepth).
    */
-  union { null, boolean } filtersApplied = null;
+  union { null, int } referenceForwardReadDepth = null;
 
   /**
-   True if all filters for this genotype call passed. FORMAT field "FT" value PASS.
+   Per-sample reverse strand reference read depth. VCF genotype reserved key ADR, Number=R,
+   split for multiallelic sites into single integer values for the reference allele
+   (referenceReverseReadDepth, this field) and the alternate allele (alternateReverseReadDepth).
    */
-  union { null, boolean } filtersPassed = null;
+  union { null, int } referenceReverseReadDepth = null;
 
   /**
-   Zero or more filters that failed for this genotype call from FORMAT field "FT".
+   Read depth at this position for this sample. VCF genotype field reserved key DP, Number=1.
    */
-  array<string> filtersFailed = [];
+  union { null, int } readDepth = null;
+
+  /**
+   Log scaled genotype likelihoods. VCF genotype field reserved key GL, Number=G, converted
+   from log10 scale to natural log scale, or VCF genotype field reserved key PL, Number=G,
+   converted from phred scale to natural log scale.
+   */
+  array<double> likelihoods = [];
+
+  /**
+   Log scaled likelihoods that we have n non-reference alleles at this site. The number of
+   elements in this array should be equal to the ploidy at this site, plus 1.  VCF genotype
+   field key nonReferenceLikelihoods, Number=..
+   */
+  array<double> nonReferenceLikelihoods = [];
+
+  /**
+   Log scaled prior probabilities. VCF genotype field key priors, Number=G.
+   */
+  array<float> priors = [];
+
+  /**
+   Log scaled posterior probabilities. VCF genotype field reserved key GP, Number=G, converted
+   from log10 scale to natural log scale.
+   */
+  array<float> posteriors = [];
+
+  /**
+   Conditional genotype quality, encoded as a phred quality −10log10 p(genotype call is wrong
+   conditioned on the site being variant). VCF genotype field reserved key GQ, Number=1.
+   */
+  union { null, int } quality = null;
+
+  /**
+   For a gVCF block, the minimum phred-scaled probability of the reference genotype call for
+   all bases merged into this block. minGQ in the gVCF block header line, e.g. 0 in
+   ##GVCFBlock=minGQ=0(inclusive),maxGQ=5(exclusive).
+   */
+  union { null, int } minimumQuality = null;
+
+  /**
+   For a gVCF block, the maximum phred-scaled probability of the reference genotype call for
+   all bases merged into this block. maxGQ in the gVCF block header line, e.g. 5 in
+   ##GVCFBlock=minGQ=0(inclusive),maxGQ=5(exclusive).
+   */
+  union { null, int } maximumQuality = null;
+
+  /**
+   Root Mean Square (RMS) of the mapping quality of reads for this genotype. VCF genotype field
+   reserved key MQ, Number=1.
+   */
+  union { null, int } rmsMappingQuality = null;
+
+  /**
+   Phred-scaled probability that alleles are ordered incorrectly, against all other members in
+   the same phase set. VCF genotype field reserved key PQ, Number=1.
+   */
+  union { null, int } phaseSetQuality = null;
+
+  /**
+   Minimum number of reads seen at this site across samples when joint calling variants.
+   VCF genotype field key MIN_DP, Number=1.
+   */
+  union { null, int } minimumReadDepth = null;
 
   /**
    True if the reads covering this site were randomly downsampled to reduce coverage.
@@ -959,82 +1022,19 @@ record VariantCallingAnnotations {
   union { null, boolean } downsampled = null;
 
   /**
-   The Wilcoxon rank-sum test statistic of the base quality scores. The base quality
-   scores are separated by whether or not the base supports the reference or the
-   alternate allele.
-   */
-  union { null, float } baseQRankSum = null;
-
-  /**
-   The Fisher's exact test score for the strand bias of the reference and alternate
-   alleles. Stored as a phred scaled probability. Thus, if:
-
-   * a = The number of positive strand reads covering the reference allele
-   * b = The number of positive strand reads covering the alternate allele
-   * c = The number of negative strand reads covering the reference allele
-   * d = The number of negative strand reads covering the alternate allele
-
-   This value takes the score:
-   
-   -10 log((a + b)! * (c + d)! * (a + c)! * (b + d)! / (a! b! c! d! n!)
-
-   Where n = a + b + c + d.
+   Fisher's exact test score for the strand bias of the reference and alternate alleles.
+   VCF genotype field key fisherStrandBiasPValue, Number=1 Type=Float.
    */
   union { null, float } fisherStrandBiasPValue = null;
 
   /**
-   The root mean square of the mapping qualities of reads covering this site.
-   */
-  union { null, float } rmsMapQ = null;
-  
-  /**
-   The number of reads at this site with mapping quality equal to 0.
-   */
-  union { null, int } mapq0Reads = null;
-
-  /**
-   The Wilcoxon rank-sum test statistic of the mapping quality scores. The mapping
-   quality scores are separated by whether or not the read supported the reference or the
-   alternate allele.
-   */
-  union { null, float } mqRankSum = null;
-
-  /**
-   The Wilcoxon rank-sum test statistic of the position of the base in the read at this site.
-   The positions are separated by whether or not the base supports the reference or the
-   alternate allele.
-   */
-  union { null, float } readPositionRankSum = null;
-
-  /**
-   The log scale prior probabilities of the various genotype states at this site.
-   The number of elements in this array should be equal to the ploidy at this
-   site, plus 1.
-   */
-  array<float> genotypePriors = [];
-
-  /**
-   The log scaled posterior probabilities of the various genotype states at this site,
-   in this sample. The number of elements in this array should be equal to the ploidy at
-   this site, plus 1.
-   */
-  array<float> genotypePosteriors = [];
-
-  /**
-   The log-odds ratio of being a true vs. false variant under a trained statistical model.
-   This model can be a multivariate Gaussian mixture, support vector machine, etc.
-   */
-  union { null, float } vqslod = null;
-
-  /**
-   If known, the feature that contributed the most to this variant being classified as
-   a false variant.
-   */
-  union { null, string } culprit = null;
-
-  /**
-   Additional feature info that doesn't fit into the standard fields above.
-   They are all encoded as (string, string) key-value pairs.
+   Additional genotype attributes that do not fit into the standard fields above.
+   The values are stored as strings, even for flag, integer, and float types. VCF
+   genotype key values with Number=., Number=0, Number=1, and Number=[n] are shared across
+   all alternate alleles in the same VCF record. VCF genotype key values with Number=A are
+   split for multiallelic sites into a single value. VCF genotype key values with Number=R
+   are split into an array of two values, [reference allele, alternate allele], separated
+   by commas, e.g. "0,1".
    */
   map<string> attributes = {};
 }
@@ -1045,129 +1045,85 @@ record VariantCallingAnnotations {
 record Genotype {
 
   /**
-   The variant called at this site.
-   */
-  union { null, Variant } variant = null;
-
-  /**
-   The reference that this genotype's variant exists on.
+   The reference the variant for this genotype exists on. VCF column 1 "CONTIG".
    */
   union { null, string } referenceName = null;
 
   /**
-   The zero-based start position of this genotype's variant on the reference.
+   The zero-based start position of the variant for this genotype on the reference.
+   VCF column 2 "POS" converted to zero-based coordinate system, closed-open intervals.
    */
   union { null, long } start = null;
 
   /**
-   The zero-based, exclusive end position of this genotype's variant on the reference.
+   The zero-based, exclusive end position of the variant for this genotype on the reference.
+   Calculated by start + referenceAllele.length().
    */
   union { null, long } end = null;
 
   /**
-   Statistics collected at this site, if available.
+   True if this genotype was split from a multiallelic site in VCF.
    */
-  union { null, VariantCallingAnnotations } variantCallingAnnotations = null;
+  union { boolean, null } splitFromMultiallelic = false;
 
   /**
-   The unique identifier for this sample. Join with Sample.id for sample metadata.
+   A string describing the reference allele of the variant for this genotype.
+   VCF column 4 "REF".
    */
-  union { null, string }  sampleId = null;
+  union { null, string } referenceAllele = null;
 
   /**
-   A description of this sample.
+   A string describing the alternate allele of the variant for this genotype.
+   VCF column 5 "ALT" split for multiallelic sites.
    */
-  union { null, string }  sampleDescription = null;
+  union { null, string } alternateAllele = null;
 
   /**
-   A string describing the provenance of this sample and the processing applied
-   in genotyping this sample.
+   Sample identifier for this genotype. Join with Sample.id for sample metadata.
+   VCF header line sample id.
    */
-  union { null, string }  processingDescription = null;
+  union { null, string } sampleId = null;
 
   /**
-   An array describing the genotype called at this site. The length of this
-   array is equal to the ploidy of the sample at this site. This array may
-   reference OTHER_ALT alleles if this site is multi-allelic in this sample.
+   One or more allele values encoding this genotype. If this genotype is phased, the order of
+   the allele values is significant. VCF genotype field reserved key GT mapped to Allele enum
+   values.
    */
-  array<GenotypeAllele> alleles = [];
+  array<Allele> alleles = [];
 
   /**
-   The expected dosage of the alternate allele in this sample.
-   */
-  union { null, float } expectedAlleleDosage = null;
-
-  /**
-   The number of reads that show evidence for the reference at this site.
-   */
-  union { null, int } referenceReadDepth = null;
-
-  /**
-   The number of reads that show evidence for this alternate allele at this site.
-   */
-  union { null, int } alternateReadDepth = null;
-
-  /**
-   The total number of reads at this site. May not equal (alternateReadDepth +
-   referenceReadDepth) if this site shows evidence of multiple alternate alleles.
-   Analogous to VCF's DP.
-   */
-  union { null, int } readDepth = null;
-
-  /**
-   The minimum number of reads seen at this site across samples when joint
-   calling variants. Analogous to VCF's MIN_DP.
-   */
-  union { null, int } minReadDepth = null;
-
-  /**
-   The phred-scaled probability that we're correct for this genotype call.
-   Analogous to VCF's GQ.
-   */
-  union { null, int } genotypeQuality = null;
-
-  /**
-   Log scaled likelihoods that we have n copies of this alternate allele.
-   The number of elements in this array should be equal to the ploidy at this
-   site, plus 1. Analogous to VCF's PL.
-   */
-  array<double> genotypeLikelihoods = [];
-
-  /**
-   Log scaled likelihoods that we have n non-reference alleles at this site.
-   The number of elements in this array should be equal to the ploidy at this
-   site, plus 1.
-   */
-  array<double> nonReferenceLikelihoods = [];
-
-  /**
-   Component statistics which comprise the Fisher's Exact Test to detect strand bias.
-   If populated, this element should have length 4.
-   */
-  array<int> strandBiasComponents = [];
-
-  /**
-   We split multi-allelic VCF lines into multiple single-alternate records.
-   This bit is set if that happened for this record.
-   */
-  union { boolean, null } splitFromMultiAllelic = false;
-
-  /**
-   True if this genotype is phased.
+   True if this genotype is phased. If true, the order of alleles is significant. VCF genotype field
+   reserved key GT allele separators: '|' genotype is phased; '/' genotype is unphased.
    */
   union { boolean, null } phased = false;
 
   /**
-   The ID of this phase set, if this genotype is phased. Should only be populated
-   if phased == true; else should be null.
+   Phase set, if any. Phased genotypes on the same contig with the same phaseSet
+   are in the same phased set. All phased genotypes that do not have a phaseSet are assumed to
+   belong to the same phased set. VCF genotype field reserved key PS, Number=1.
    */
-  union { null, int } phaseSetId = null;
+  union { null, int } phaseSet = null;
 
   /**
-   Phred scaled quality score for the phasing of this genotype, if this genotype
-   is phased. Should only be populated if phased == true; else should be null.
+   True if filters were applied for this genotype. VCF genotype field reserved key FT any
+   value other than the missing value.
    */
-  union { null, int } phaseQuality = null;
+  union { null, boolean } filtersApplied = null;
+
+  /**
+   True if all filters for this genotype passed. VCF genotype field reserved key FT value PASS.
+   */
+  union { null, boolean } filtersPassed = null;
+
+  /**
+   Zero or more filters that failed for this genotype. VCF genotype field reserved key FT.
+   */
+  array<string> filtersFailed = [];
+
+  /**
+   Annotation for this genotype, if any.
+   */
+  union { null, GenotypeAnnotation } annotation = null;
 }
 
 /**


### PR DESCRIPTION
Fixes #106
Incorporates feedback from and replaces #108.
Note the diff is somewhat hard to read, for review please consider the [whole file link](https://github.com/bigdatagenomics/bdg-formats/blob/c46cda30839286a66e9ef1f3a1bef6ad236dc7d3/src/main/resources/avro/bdg.avdl).